### PR TITLE
Adding to formatting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,15 @@ You can use this list one of two ways:
  - Overriding DNS for these hostnames to point to the IP of your cache server.
  - Use them in Squid with WCCP to redirect content to the right cache server.
 
-There is a separate file for each caching service. Some notes on formatting:
+There is a separate file for each cacheable service. Some notes on formatting:
 
   - Every line should be a seperate hostname for that service.
-  - Wildcards can be represented with a space.
+  - Wildcards can be represented with an asterix.
+  - Only one wildcard is permitted per line.
+  - If a wildcard is used, it should be the first character on the line.
+  - Wildcards are not treated as matching null, e.g. `*.example.com` will match `a.example.com` but will not match `example.com`
   - Lines starting with a # will be treated as a comment.
+  - Files must end with an empty newline.
 
 ## Updates
 

--- a/origin.txt
+++ b/origin.txt
@@ -3,3 +3,4 @@ origin-a.akamaihd.net
 akamai.cdn.ea.com
 lvlt.cdn.ea.com
 river.data.ea.com
+origin-a.akamaihd.net.edgesuite.net

--- a/riot.txt
+++ b/riot.txt
@@ -1,2 +1,4 @@
 l3cdn.riotgames.com
 worldwide.l3cdn.riotgames.com
+riotgamespatcher-a.akamaihd.net
+riotgamespatcher-a.akamaihd.net.edgesuite.net

--- a/steam.txt
+++ b/steam.txt
@@ -17,3 +17,6 @@ clientconfig.akamai.steamtransparent.com
 steampipe.akamaized.net
 edgecast.steamstatic.com
 steam.apac.qtlglb.com.mwcloudcdn.com
+*.cs.steampowered.com
+*.edgecast.steamstatic.com
+*.steamcontent.com

--- a/windowsupdates.txt
+++ b/windowsupdates.txt
@@ -1,2 +1,4 @@
-download.windowsupdate.com
 officecdn.microsoft.com
+*.windowsupdate.com
+windowsupdate.com
+*.dl.delivery.mp.microsoft.com


### PR DESCRIPTION
I've just started using this repo's text files in an automated script to build nginx configuration files, and have added a few additional formatting notes to make sure that the text files can continue to be revised in such a way that won't break scripts.

Regarding wildcards, nginx's server_name wildcard matching behaviour is such that *.example.com will match a.example.com but will not match example.com:

    A special wildcard name in the form “.example.org” can be used to match both the exact name “example.org” and the wildcard name “*.example.org”.
    http://nginx.org/en/docs/http/server_names.html#wildcard_names

I think that following that same convention in these text files is the logical thing to do too.

Additionally, multiple wildcards per hostname is not supported by nginx without using regular expressions, but thankfully no services appear to need this kind of matching.

Feedback welcomed :)