### PR TITLE
Added new cache_domains file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,29 @@ You can use this list one of two ways:
  - Overriding DNS for these hostnames to point to the IP of your cache server.
  - Use them in Squid with WCCP to redirect content to the right cache server.
 
+There is a cache_domains.json file to define CDNs and additional meta deta with the following structure
+
+- cache_domains: Array of cache_domain object
+	- name: shortname for the cache domain
+	- description: a longer description to aid others in identifying what this domain does (not all users of this repo will want to enable all caches)
+	- notes: implementation specific notes which may be useful for other users
+	- mixed_content: true if this domain hosts mixed https and http content (a straight dns injection is unlikely to work in this case). Assumed to be false if undefined
+	- domain_files: array of files within the repo assosciated to the cdn. Most cdn's only need one file
+	- Example domain entry for origin
+```json
+{
+	"cache_domains": [
+		{
+			"name": "origin",
+			"description": "CDN for origin",
+			"notes": "Should be enabled for HTTP traffic only or with a HTTPS proxy else origin client download fails",
+			"mixed_content": true,
+			"domain_files": ["origin.txt"]
+		}
+	]
+}
+```
+
 There is a separate file for each cacheable service. Some notes on formatting:
 
   - Every line should be a seperate hostname for that service.
@@ -24,6 +47,10 @@ There is a separate file for each cacheable service. Some notes on formatting:
 ## Updates
 
 Please fork this repository and submit pull requests if you have any extra hostnames or services to add. We want this list to be definitive and collaborative!
+
+### New CDNs
+
+If the CDN you are adding does not already exist please remember to add an entry within cache_domains.json as well as a new .txt file
 
 ## Issues and Feedback
 

--- a/cache_domains.json
+++ b/cache_domains.json
@@ -1,0 +1,97 @@
+{
+	"cache_domains": [
+		{
+			"name": "apple",
+			"description": "CDN for apple",
+			"domain_files": ["apple.txt"]
+		},
+		{
+			"name": "arenanet",
+			"description": "CDN for guild wars, HoT",
+			"domain_files": ["arenanet.txt"]
+		},
+		{
+			"name": "blizzard",
+			"description": "CDN for blizzard/battle.net",
+			"domain_files": ["blizzard.txt"]
+		},
+		{
+			"name": "frontier",
+			"description": "CDN for frontier games",
+			"domain_files": ["frontier.txt"]
+		},
+		{
+			"name": "gog",
+			"description": "CDN for good old games downloader",
+			"domain_files": ["gog.txt"]
+		},
+		{
+			"name": "hirez",
+			"description": "CDN for hirez",
+			"domain_files": ["hirez.txt"]
+		},
+		{
+			"name": "minecraft",
+			"description": "CDN for minecraft client and updater",
+			"domain_files": ["minecraft.txt"]
+		},
+		{
+			"name": "nexusmods",
+			"description": "Nexus mods / skyrim content",
+			"domain_files": ["nexusmods.txt"]
+		},
+		{
+			"name": "nintendo",
+			"description": "CDN for nintendo (swtich)",
+			"domain_files": ["nintendo.txt"]
+		},
+		{
+			"name": "origin",
+			"description": "CDN for origin",
+			"notes": "Should be enabled for HTTP traffic only or with a HTTPS proxy else origin client download fails",
+			"mixed_content": true,
+			"domain_files": ["origin.txt"]
+		},
+		{
+			"name": "riot",
+			"description": "CDN for riot games",
+			"domain_files": ["riot.txt"]
+		},
+		{
+			"name": "rockstar",
+			"description": "CDN for rockstar games",
+			"domain_files": ["rockstar.txt"]
+		},
+		{
+			"name": "sony",
+			"description": "CDN for sony / playstation",
+			"domain_files": ["sony.txt"]
+		},
+		{
+			"name": "steam",
+			"description": "CDN for steam platform",
+			"domain_files": ["steam.txt"]
+		},
+		{
+			"name": "uplay",
+			"description": "CDN for uplay downloader",
+			"domain_files": ["uplay.txt"]
+		},
+		{
+			"name": "wargaming",
+			"description": "CDN for wargaming.net",
+			"domain_files": ["wargaming.net.txt"]
+		},
+		{
+			"name": "wsus",
+			"description": "CDN for windows updates",
+			"domain_files": ["windowsupdates.txt"]
+		},
+		{
+			"name": "xboxlive",
+			"description": "CDN for xboxlive",
+			"domain_files": ["xboxlive.txt"]
+		}
+	]
+}
+


### PR DESCRIPTION
Added new cache_domains.json file to allow machine readable metadata to
be added about the CDN's configured here. Initialised with skeleton for
all current files

Updated README.md to explain the structure.