### PR TITLE
Update steam.txt with second comcast dns

### DIFF
--- a/steam.txt
+++ b/steam.txt
@@ -25,3 +25,4 @@ cdn2-sea1.valve.net
 *.steam-content-dnld-1.apac-1-cdn.cqloud.com
 steam.apac.qtlglb.com
 edge.steam-dns.top.comcast.net
+edge.steam-dns-2.top.comcast.net


### PR DESCRIPTION
seeing a lot of requests to the following dns when downloading steam content: edge.steam-dns-2.top.comcast.net

unsure if I should add *.top.comcast.net as if that would be too greedy?