### PR TITLE
Update windows domains to include the base domain

### DIFF
--- a/windowsupdates.txt
+++ b/windowsupdates.txt
@@ -2,3 +2,4 @@ officecdn.microsoft.com
 *.windowsupdate.com
 windowsupdate.com
 *.dl.delivery.mp.microsoft.com
+dl.delivery.mp.microsoft.com


### PR DESCRIPTION
This potentially fixes issue with caching Windows Store app updates.