### PR TITLE
Minecraft CDN moved over to HTTPS

### DIFF
--- a/cache_domains.json
+++ b/cache_domains.json
@@ -31,11 +31,6 @@
 			"domain_files": ["hirez.txt"]
 		},
 		{
-			"name": "minecraft",
-			"description": "CDN for minecraft client and updater",
-			"domain_files": ["minecraft.txt"]
-		},
-		{
 			"name": "nexusmods",
 			"description": "Nexus mods / skyrim content",
 			"domain_files": ["nexusmods.txt"]

--- a/minecraft.txt
+++ b/minecraft.txt
@@ -1,1 +1,0 @@
-*.download.minecraft.net


### PR DESCRIPTION
### What CDN does this PR relate to
download.minecraft.net

### Does this require running via sniproxy
Yes

### Capture method
Fiddler 4

### Testing Scenario
Tested at home, setup a SNIproxy, 4 different lancaches (Uplay, Steam, Blizzard and Minecraft) using steamcache/generic. Steamcache, Blizzard and Uplay works smoothly after setting DNS ip to server ip hosting steamcache-dns. Minecraft uses https now instead.

### Sniproxy output
`2018-12-09 16:17:21 192.168.1.43:34138 -> 0.0.0.0:443 -> 143.204.47.64:443 [resources.download.minecraft.net] 47819730/47819730 bytes tx 296544/296544 bytes rx 10.343 seconds`

