### PR TITLE
Remove images-eds from xboxlive

### DIFF
--- a/xboxlive.txt
+++ b/xboxlive.txt
@@ -4,6 +4,5 @@ dlassets.xboxlive.com
 xboxone.loris.llnwd.net
 *.xboxone.loris.llnwd.net
 xboxone.vo.llnwd.net
-images-eds.xboxlive.com
 xbox-mbr.xboxlive.com
 assets1.xboxlive.com.nsatc.net


### PR DESCRIPTION
### What CDN does this PR relate to
Images-eds now serves all images from /image causing cache conflicts. Removed until further debugging provides a need to readd.
Resolves #49


### Does this require running via sniproxy
No

### Capture method
Issue #49 

### Testing Scenario
Analysis of nginx logs clearly shows the multiple `/image?url=` requests. Agreement in uklans discord to remove and stop tracking

