### PR TITLE
Updating nintendo.txt for support for the Wii U

### DIFF
--- a/nintendo.txt
+++ b/nintendo.txt
@@ -1,8 +1,13 @@
 ccs.cdn.wup.shop.nintendo.com
-pushmo.hac.lp1.eshop.nintendo.net
+ccs.cdn.wup.shop.nintendo.net
+ccs.cdn.wup.shop.nintendo.net.edgesuite.net
 ecs-lp1.hac.shop.nintendo.net
 receive-lp1.dg.srv.nintendo.net
 aqua.hac.lp1.d4c.nintendo.net
 atum.hac.lp1.d4c.nintendo.net
 bugyo.hac.lp1.eshop.nintendo.net
+pushmo.hac.lp1.eshop.nintendo.net
 tagaya.hac.lp1.eshop.nintendo.net
+*.deploy.static.akamaitechnologies.com
+*.root-servers.net
+a1702.g.akamai.net


### PR DESCRIPTION
Added web addresses for LAN Cache support for the Nintendo Wii U, Logged and noted from Wireshark, also minor re-organization of web addresses

### What CDN does this PR relate to
Nintendo, the Wii U specifically. (or #68 it meant?)

Only tested with Mario Kart 8 DLC, so far

### Does this require running via sniproxy
Untested, currently.

### Capture method
Captured the incoming/outgoing packets via Wireshark

### Testing Scenario
I have plan to test it soon, and at home, but not knowing where to make the changes for my local files

### Testing Configuration
```
<!-- Paste either your docker run command from the DNS container OR explain how you have setup DNS zone files etc to test this issue -->
```

### Sniproxy output
Please paste the output from `docker logs <sniproxy container name/id> | sed 's/.*\:443 \[//;s/\].*//' | sort | uniq -c` below
```
<!-- If you are running sniproxy paste the output to the following command
docker logs sniproxy | sed 's/.*\:443 \[//;s/\].*//' | sort | uniq -c
-->
```

