### PR TITLE
Re-add minecraft.txt for Minecraft

### DIFF
--- a/cache_domains.json
+++ b/cache_domains.json
@@ -31,6 +31,11 @@
 			"domain_files": ["hirez.txt"]
 		},
 		{
+			"name": "minecraft",
+			"description": "CDN for the Minecraft Launcher and its libraries",
+			"domain_files": ["minecraft.txt"]
+		},
+		{
 			"name": "nexusmods",
 			"description": "Nexus mods / skyrim content",
 			"domain_files": ["nexusmods.txt"]

--- a/minecraft.txt
+++ b/minecraft.txt
@@ -1,5 +1,5 @@
 launcher.mojang.com
 launchermeta.mojang.com
-libraries.minecraft.net
+libraries.minecraft.net # Unable to test via web browser due to 403 Error
 resources.minecraft.net # How did I get this from the minecraft launcher?
 resources.download.minecraft.net

--- a/minecraft.txt
+++ b/minecraft.txt
@@ -1,5 +1,5 @@
 launcher.mojang.com
 launchermeta.mojang.com
-libraries.minecraft.net # Unable to test via web browser due to 403 Error
-resources.minecraft.net # How did I get this from the minecraft launcher?
+libraries.minecraft.net
+resources.minecraft.net
 resources.download.minecraft.net

--- a/minecraft.txt
+++ b/minecraft.txt
@@ -1,0 +1,5 @@
+launcher.mojang.com
+launchermeta.mojang.com
+libraries.minecraft.net
+resources.minecraft.net
+resources.download.minecraft.net

--- a/minecraft.txt
+++ b/minecraft.txt
@@ -1,5 +1,5 @@
 launcher.mojang.com
 launchermeta.mojang.com
 libraries.minecraft.net
-resources.minecraft.net
+resources.minecraft.net # How did I get this from the minecraft launcher?
 resources.download.minecraft.net


### PR DESCRIPTION
### What CDN does this PR relate to
A previously available CDN before it was deleted without a valid reasoning.

### Does this require running via sniproxy
N/A (does it mean a "No" if you can download the files via http anyway?)

### Capture method
Via the minecraft launcher log

### Testing Scenario
<!-- Please give a short description on how you have tested this and where (home, office, small lan, large lan etc) -->

### Testing Configuration
```
<!-- Paste either your docker run command from the DNS container OR explain how you have setup DNS zone files etc to test this issue -->
```
