### PR TITLE
Update steam.txt

### DIFF
--- a/steam.txt
+++ b/steam.txt
@@ -24,8 +24,6 @@ cdn1-sea1.valve.net
 cdn2-sea1.valve.net
 *.steam-content-dnld-1.apac-1-cdn.cqloud.com
 steam.apac.qtlglb.com
-edge.steam-dns.top.comcast.net
-edge.steam-dns-2.top.comcast.net
 steam.naeu.qtlglb.com
 steampipe-kr.akamaized.net
 steam.ix.asn.au


### PR DESCRIPTION
removed the following:

edge.steam-dns.top.comcast.net
edge.steam-dns-2.top.comcast.net

in reference to [47](https://github.com/steamcache/steamcache-dns/issues/47)

### What CDN does this PR relate to

caching steam updates/games on comcast ISP

edge.steam-dns.top.comcast.net
edge.steam-dns-2.top.comcast.net

### Does this require running via sniproxy
 Yes

### Testing Scenario
home test, can be rolled back afterwards

### Testing Configuration
```
sudo docker run --restart unless-stopped --name steamcache-dns --detach -p 172.16.10.235:53:53/udp -e USE_GENERIC_CACHE=true -e LANCACHE_IP=172.16.10.235 -e UPSTREAM_DNS=1.1.1.1 steamcache/steamcache-dns:latest
```
