### PR TITLE
Euro CDN addition

### DIFF
--- a/steam.txt
+++ b/steam.txt
@@ -18,6 +18,7 @@ steampipe.akamaized.net
 edgecast.steamstatic.com
 steam.apac.qtlglb.com.mwcloudcdn.com
 *.cs.steampowered.com
+*.cm.steampowered.com
 *.edgecast.steamstatic.com
 *.steamcontent.com
 cdn1-sea1.valve.net


### PR DESCRIPTION
Adding *.cm.steampowered.com, which is used as a CDN for many European countries.

### What CDN does this PR relate to
Relates to all Europe based steam clients, example of domains include 

CM01-LUX.cm.steampowered.com
CM02-LUX.cm.steampowered.com
cm1-par1.cm.steampowered.com
cm2-par1.cm.steampowered.com
cm1-sto1.cm.steampowered.com
cm2-sto1.cm.steampowered.com
cm3-sto1.cm.steampowered.com
cm4-sto1.cm.steampowered.com
CM01-LUX.cm.steampowered.com
CM02-LON.cm.steampowered.com
CM03-LON.cm.steampowered.com
CM04-LON.cm.steampowered.com

### Does this require running via sniproxy
No, runs through HTTP (tested)

### Capture method
Detected due to random cache misses, and diagnosed with bind9 logs and wireshark

### Testing Scenario
Tested on a 24 PC eSports centre in the UK.

### Testing Configuration
Added single entry to rpz file

### Sniproxy output
Does not hit through sniproxy


