### PR TITLE
Added ability to include multiple IP Addresses for unbound

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ The wildcard format shall be defined as per the below
 
 If you are using these files within a squid dst_domain acl you will need to reformat the wildcard entries to be compliant with the squid acl format. The following regex should suffice `s/*\./\./`
 
+### Multiple IP Addresses
+
+unbound supports assigning multiple IP addresses to a record (can be used if using multiple caches). Example config formatting:
+```json
+"ips": {
+        "steam":        [ "10.10.3.11", "10.10.3.12", "10.10.3.13" ],
+        "generic":      "10.10.3.16"
+},
+```
+
 ## Updates
 
 Please fork this repository and submit pull requests if you have any extra hostnames or services to add. We want this list to be definitive and collaborative!


### PR DESCRIPTION
### PR Details
Updated the unbound creation script to support adding multiple IP addresses for a record. This can be used if assigning multiple IPs to a caching server, or utilizing multiple caching servers at an event.

### What CDN does this PR relate to
All CDNs

### Does this require running via sniproxy
No

### Testing Scenario
Tested create-unbound.sh multiple times utilizing multiple IP address scenarios in config.json

### Testing Configuration
```json
{
	"ips": {
		"steam":	[ "10.10.3.11", "10.10.3.100", "10.10.3.101", "10.10.3.102" ],
		"origin":	"10.10.3.12",
		"blizzard":	"10.10.3.13",
		"windows":	[ "10.10.3.14", "10.10.3.200" ],
		"riot":		"10.10.3.15",
		"generic":	"10.10.3.16"
	},
	"cache_domains": {
		"default": 	"generic",
		"blizzard": 	"blizzard",
		"origin": 	"origin",
		"riot": 	"riot",
		"steam": 	"steam",
		"wsus": 	"windows",
		"xboxlive": 	"windows"
	}
}
```

