### PR TITLE
Fixes indentation and create-unbound error due to dash in epic-games naming

### DIFF
--- a/cache_domains.json
+++ b/cache_domains.json
@@ -53,11 +53,11 @@
 			"mixed_content": true,
 			"domain_files": ["origin.txt"]
 		},
-                {
-                        "name": "renegadex",
-                        "description": "CDN for Renegade X",
-                        "domain_files": ["renegadex.txt"]
-                },
+		{
+			"name": "renegadex",
+			"description": "CDN for Renegade X",
+			"domain_files": ["renegadex.txt"]
+		},
 		{
 			"name": "riot",
 			"description": "CDN for riot games",

--- a/cache_domains.json
+++ b/cache_domains.json
@@ -21,7 +21,7 @@
 			"domain_files": ["daybreak.txt"]
 		},
 		{
-			"name": "epic-games",
+			"name": "epic_games",
 			"description": "CDN for Epic Games",
 			"domain_files": ["epic-games.txt"],
 			"mixed_content": true


### PR DESCRIPTION
In create-unbound.sh the name of the configuration in cache_domains.json is used as a variable.

```
while read line; do 
        name=$(jq -r ".cache_domains[\"${line}\"]" config.json)
        declare "cachename$line"="$name"
done <<< $(jq -r '.cache_domains | to_entries[] | .key' config.json)
```

Unfortunatly for epic-games, this results in a variable called  **cachenameepic-games**  which is an invalid variable name in Bash, thus interrupting the creation of the unbound configuration files.