### PR TITLE
Deprecation of mixed-content field

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ There is a cache_domains.json file to define CDNs and additional meta deta with 
 	- name: shortname for the cache domain. Should match `^[0-9A-Za-z]$`
 	- description: a longer description to aid others in identifying what this domain does (not all users of this repo will want to enable all caches)
 	- notes: implementation specific notes which may be useful for other users
-	- mixed_content: true if this domain hosts mixed https and http content (a straight dns injection is unlikely to work in this case). Assumed to be false if undefined
 	- domain_files: array of files within the repo assosciated to the cdn. Most cdn's only need one file
 	- Example domain entry for origin
 ```json
@@ -27,7 +26,6 @@ There is a cache_domains.json file to define CDNs and additional meta deta with 
 			"name": "origin",
 			"description": "CDN for origin",
 			"notes": "Should be enabled for HTTP traffic only or with a HTTPS proxy else origin client download fails",
-			"mixed_content": true,
 			"domain_files": ["origin.txt"]
 		}
 	]

--- a/cache_domains.json
+++ b/cache_domains.json
@@ -23,8 +23,7 @@
 		{
 			"name": "epicgames",
 			"description": "CDN for Epic Games",
-			"domain_files": ["epicgames.txt"],
-			"mixed_content": true
+			"domain_files": ["epicgames.txt"]
 		},
 		{
 			"name": "frontier",
@@ -49,14 +48,12 @@
 		{
 			"name": "nintendo",
 			"description": "CDN for Nintendo consoles and download servers",
-			"domain_files": ["nintendo.txt"],
-			"mixed_content": true
+			"domain_files": ["nintendo.txt"]
 		},
 		{
 			"name": "origin",
 			"description": "CDN for origin",
 			"notes": "Should be enabled for HTTP traffic only or with a HTTPS proxy else origin client download fails",
-			"mixed_content": true,
 			"domain_files": ["origin.txt"]
 		},
 		{
@@ -92,7 +89,6 @@
 		{
 			"name": "teso",
 			"description": "CDN for The Elder Scrolls Online",
-			"mixed_content": true,
 			"domain_files": ["teso.txt"]
 		},
 		{
@@ -118,8 +114,7 @@
 		{
 			"name": "xboxlive",
 			"description": "CDN for xboxlive",
-			"domain_files": ["xboxlive.txt"],
-			"mixed_content": true
+			"domain_files": ["xboxlive.txt"]
 		}
 	]
 }


### PR DESCRIPTION
The recommendation from lancachenet/monolithic project, which is the main consumer of this repo, is to always run sniproxy in conjunction.  Thus the mixed-content field is no longer required.

