### PR TITLE
Additional Windows Server 2019 WSUS domains

### DIFF
--- a/windowsupdates.txt
+++ b/windowsupdates.txt
@@ -6,3 +6,8 @@ dl.delivery.mp.microsoft.com
 *.update.microsoft.com
 *.do.dsp.mp.microsoft.com
 *.microsoft.com.edgesuite.net
+amupdatedl.microsoft.com
+amupdatedl2.microsoft.com
+amupdatedl3.microsoft.com
+amupdatedl4.microsoft.com
+amupdatedl5.microsoft.com


### PR DESCRIPTION
Additional Windows update domains which appear to be utilised by Windows Server 2019, closes #99.

Given that the added domains are CNAME records to the existing captured domain `*.microsoft.com.edgesuite.net` this is purely for logging and downstream reporting.