### PR TITLE
Domain correction for Riot's new chunking patcher

### DIFF
--- a/riot.txt
+++ b/riot.txt
@@ -2,4 +2,4 @@ l3cdn.riotgames.com
 worldwide.l3cdn.riotgames.com
 riotgamespatcher-a.akamaihd.net
 riotgamespatcher-a.akamaihd.net.edgesuite.net
-lol.dyn.riotcdn.net
+*.dyn.riotcdn.net


### PR DESCRIPTION
### What CDN does this PR relate to

All Riot Games 

### Does this require running via sniproxy

No, this domain is dedicated to mixed HTTP/HTTPS content and the patcher is designed to gracefully degrade to HTTP when this domain resolves to an RFC1918, RFC4193, or a link-local address.

### Capture method

I designed the CDN topology ;)


