### PR TITLE
Add support for City of Heroes (Homecoming)

### DIFF
--- a/cache_domains.json
+++ b/cache_domains.json
@@ -16,6 +16,11 @@
 			"domain_files": ["blizzard.txt"]
 		},
 		{
+			"name": "cityofheroes",
+			"description": "CDN for City of Heroes (Homecoming)",
+			"domain_files": ["cityofheroes.txt"]
+		},
+		{
 			"name": "daybreak",
 			"description": "Daybreak games CDN",
 			"domain_files": ["daybreak.txt"]

--- a/cityofheroes.txt
+++ b/cityofheroes.txt
@@ -1,0 +1,1 @@
+cdn.homecomingservers.com


### PR DESCRIPTION
### What CDN does this PR relate to
This PR adds support for City of Heroes Homecoming.

### Does this require running via sniproxy
No.

### Capture method
Collaboration with the Homecoming server admin team. They have deployed a new CDN following our caching guidelines.

### Testing Scenario
Tested locally.

### Testing Configuration
N/A

### Sniproxy output
N/A

