### PR TITLE
Added Adobe CDN, Google CDN and new Apple CDN domains

### DIFF
--- a/adobe.txt
+++ b/adobe.txt
@@ -1,0 +1,4 @@
+ardownload.adobe.com
+ccmdl.adobe.com
+agsupdate.adobe.com
+*.adobe.com.edgesuite.net

--- a/apple.txt
+++ b/apple.txt
@@ -1,1 +1,5 @@
+appldnld.apple.com
+iosapps.itunes.apple.com
+updates-http.cdn-apple.com
+osxapps.itunes.apple.com
 swcdn.apple.com

--- a/cache_domains.json
+++ b/cache_domains.json
@@ -1,6 +1,11 @@
 {
 	"cache_domains": [
 		{
+                        "name": "adobe",
+                        "description": "CDN for Adobe",
+                        "domain_files": ["adobe.txt"]
+                },
+		{
 			"name": "apple",
 			"description": "CDN for apple",
 			"domain_files": ["apple.txt"]

--- a/cache_domains.json
+++ b/cache_domains.json
@@ -41,6 +41,11 @@
 			"domain_files": ["frontier.txt"]
 		},
 		{
+            "name": "google",
+            "description" : "CDN for Google Chrome and ChromeOS",
+            "domain_files": ["google.txt"]
+        },
+		{
 			"name": "hirez",
 			"description": "CDN for hirez",
 			"domain_files": ["hirez.txt"]

--- a/google.txt
+++ b/google.txt
@@ -1,0 +1,2 @@
+dl.google.com
+*.gvt1.com

--- a/sony.txt
+++ b/sony.txt
@@ -1,4 +1,4 @@
 pls.patch.station.sony.com
 gs2.ww.prod.dl.playstation.net
 gs2.sonycoment.loris-e.llnwd.net
-ic.02cb9d00.078b23.gs2.sonycoment.loris-e.llnwd.net
+*.gs2.sonycoment.loris-e.llnwd.net

--- a/sony.txt
+++ b/sony.txt
@@ -1,3 +1,4 @@
 pls.patch.station.sony.com
 gs2.ww.prod.dl.playstation.net
 gs2.sonycoment.loris-e.llnwd.net
+ic.02cb9d00.078b23.gs2.sonycoment.loris-e.llnwd.net


### PR DESCRIPTION
### What CDN does this PR relate to
New Adobe CDN
New Google CDN
Extended Apple CDN

### Does this require running via sniproxy
Untested

### Capture method
Found at another lancache project
https://github.com/tsvcathed/nginx_lancache

### Testing Scenario
Home and small lan

### Testing Configuration
1. Created dnsmasq conf files using the script.
2. Setup pihole to use these conf files

### Sniproxy output
None