### PR TITLE
Removed apple.txt as this only caters to small windows based apple apps

### DIFF
--- a/apple.txt
+++ b/apple.txt
@@ -1,1 +1,0 @@
-swcdn.apple.com

--- a/cache_domains.json
+++ b/cache_domains.json
@@ -1,11 +1,6 @@
 {
 	"cache_domains": [
 		{
-			"name": "apple",
-			"description": "CDN for apple",
-			"domain_files": ["apple.txt"]
-		},
-		{
 			"name": "arenanet",
 			"description": "CDN for guild wars, HoT",
 			"domain_files": ["arenanet.txt"]


### PR DESCRIPTION
### What CDN does this PR relate to
Removal of apple cdn. It appears the cdn only covers small windows based apple apps and doesn't really fit the purpose of the cache project. OS updates can only be used with a proxy that is setup on a mac server. 

