### PR TITLE
[wip] Apple (Software Update, iTunes)

### DIFF
--- a/apple.txt
+++ b/apple.txt
@@ -1,0 +1,17 @@
+albert.apple.com
+appldnld.apple.com
+configuration.apple.com
+*.cdn-apple.com
+deimos3.apple.com
+gg*.apple.com
+gs.apple.com
+itunes.apple.com
+*.itunes.apple.com
+mesu.apple.com
+*.mzstatic.com
+skl.apple.com
+swscan.apple.com
+swdownload.apple.com
+swcdn.apple.com
+swdist.apple.com
+xp.apple.com

--- a/cache_domains.json
+++ b/cache_domains.json
@@ -1,6 +1,11 @@
 {
 	"cache_domains": [
 		{
+			"name": "apple",
+			"description": "CDN for Apple Software Update, iTunes"
+			"domain_files": ["apple.txt"]
+		},
+		{
 			"name": "arenanet",
 			"description": "CDN for guild wars, HoT",
 			"domain_files": ["arenanet.txt"]

--- a/cache_domains.json
+++ b/cache_domains.json
@@ -2,7 +2,7 @@
 	"cache_domains": [
 		{
 			"name": "apple",
-			"description": "CDN for Apple Software Update, iTunes"
+			"description": "CDN for Apple Software Update, iTunes",
 			"domain_files": ["apple.txt"]
 		},
 		{


### PR DESCRIPTION
### What CDN does this PR relate to
Apple's CDN's (macOS software update, iOS/macOS app store, iTunes and more) collected from https://support.apple.com/en-us/HT201999

### Does this require running via sniproxy
untested

### Capture method
https://support.apple.com/en-us/HT201999

### Testing Scenario
<!-- Please give a short description on how you have tested this and where (home, office, small lan, large lan etc) -->

### Testing Configuration
```
<!-- Paste either your docker run command from the DNS container OR explain how you have setup DNS zone files etc to test this issue -->
```

### Sniproxy output
Please paste the output from `docker logs <sniproxy container name/id> | sed 's/.*\:443 \[//;s/\].*//' | sort | uniq -c` below
```
<!-- If you are running sniproxy paste the output to the following command
docker logs <sniproxy container name/id> | sed 's/.*\:443 \[//;s/\].*//' | sort | uniq -c
-->
```


Currently untested, but will test it with macOS software update, iTunes/etc when I have a chance to

