### PR TITLE
Added VoD Twitch domain

### DIFF
--- a/twitch.txt
+++ b/twitch.txt
@@ -2,3 +2,4 @@ d3rmjivj4k4f0t.cloudfront.net
 addons.forgesvc.net
 media.forgecdn.net
 files.forgecdn.net
+vod-metro.twitch.tv


### PR DESCRIPTION
### What CDN does this PR relate to
This adds a Video on Demand (VoD) domain to the `twitch.txt` to be able to cache VoD content from the Twitch platform.

### Does this require running via sniproxy
untested

I have a working lancache setup including dns as well as sniproxy, but have not yet tested this domain since it would require to build a new docker container. If necessary I can do this.

### Capture method
I opened a VoD Twitch video ([this one](https://www.twitch.tv/videos/514830917)) and looked at the Network tab of the Firefox debug console. It clearly shows that the video content is served using the given domain:

![image](https://user-images.githubusercontent.com/14024504/70675656-15800f00-1c8a-11ea-8c9b-c34618522d5c.png)

The URLs contain a hash that is unique per video, so it should be pretty easy to cache their content without messing up other videos.

Example URLs:
```
https://vod-metro.twitch.tv/42c201ea80ae75e56dd3_gronkh_218484865_13704370/chunked/1.ts
https://vod-metro.twitch.tv/42c201ea80ae75e56dd3_gronkh_218484865_13704370/chunked/2.ts
https://vod-metro.twitch.tv/42c201ea80ae75e56dd3_gronkh_218484865_13704370/chunked/3.ts
```

Other video:
```
https://vod-metro.twitch.tv/86e14cd4a552d7534c2b_gronkh_238461217_14952980/720p60/1.ts
https://vod-metro.twitch.tv/86e14cd4a552d7534c2b_gronkh_238461217_14952980/720p60/2.ts
https://vod-metro.twitch.tv/86e14cd4a552d7534c2b_gronkh_238461217_14952980/720p60/3.ts
```

### Testing Scenario
home

I did not really test this, as mentioned above. If necessary I can do this.

### Testing Configuration
N/A

### Sniproxy output
N/A

Since the domain is `https` I assume the sniproxy is necessary, but that is just a guess since I don't exactly know what the sniproxy is doing.
