### PR TITLE
Add Supreme Commander FAF content into cached domains 

### DIFF
--- a/cache_domains.json
+++ b/cache_domains.json
@@ -112,7 +112,7 @@
 		}
 		{
 			"name": "SupComFAF",
-			"description": "CDN for Supreme Commander FAF",
+			"description": "CDN for SupCom FAF",
 			"domain_files": ["faf.txt"]
 		}
 	]

--- a/cache_domains.json
+++ b/cache_domains.json
@@ -110,5 +110,10 @@
 			"description": "CDN for xboxlive",
 			"domain_files": ["xboxlive.txt"]
 		}
+		{
+			"name": "SupComFAF",
+			"description": "CDN for Supreme Commander FAF",
+			"domain_files": ["faf.txt"]
+		}
 	]
 }

--- a/faf.txt
+++ b/faf.txt
@@ -1,0 +1,1 @@
+content.faforever.com


### PR DESCRIPTION
### What CDN does this PR relate to
For Supreme Commander FAF community - cache downloads to local 

### Does this require running via sniproxy
No 

### Capture method
Captured requests via local transparent Squid trace while updating game. 

### Testing Scenario
Home, LAN 

### Testing Configuration
Currently i had inserted faf.txt into steamcache/mono container, then used upsteam resolver to force content.faforever.com requests to local server. 



