### PR TITLE
Fix duplicate check - too unspecific

### DIFF
--- a/scripts/create-unbound.sh
+++ b/scripts/create-unbound.sh
@@ -52,7 +52,7 @@ while read entry; do
 					continue
 				fi
 				parsed=$(echo $fileentry | sed -e "s/^\*\.//")
-				if grep -q "$parsed" $outputfile; then
+				if grep -qx "$parsed" $outputfile; then
 					continue
 				fi
 				echo "  local-zone: \"${parsed}\" redirect" >> $outputfile


### PR DESCRIPTION
The check is too unspecific, it currently allows partial line matches.

This prevents broader entries to be added after more specific ones.

Example: after lancache.steamcontent.com is added, steamcontent.com will be wrongfully skipped.

This change will make sure only exact duplicates are skipped.