### PR TITLE
Added BSG entry for Tarkov

### DIFF
--- a/cache_domains.json
+++ b/cache_domains.json
@@ -11,6 +11,11 @@
 			"domain_files": ["blizzard.txt"]
 		},
 		{
+			"name": "bsg",
+			"description": "CDN for Battle State Games, Tarkov",
+			"domain_files": ["bsg.txt"]
+		},
+		{
 			"name": "cityofheroes",
 			"description": "CDN for City of Heroes (Homecoming)",
 			"domain_files": ["cityofheroes.txt"]


### PR DESCRIPTION
### What CDN does this PR relate to

Battle State Games
Updated "cache-domains.json" to include bsg.txt entry.

### Does this require running via sniproxy
untested

### Capture method
N/A

### Testing Scenario
N/A 

### Testing Configuration
N/A

### Sniproxy output
N/A

