### PR TITLE
Path Of Exile CDN added

### DIFF
--- a/cache_domains.json
+++ b/cache_domains.json
@@ -63,6 +63,11 @@
 			"domain_files": ["origin.txt"]
 		},
 		{
+			"name": "pathofexile",
+			"description": "Path Of Exile CDN",
+			"domain_files": ["pathofexile.txt"]
+		},
+		{
 			"name": "renegadex",
 			"description": "CDN for Renegade X",
 			"domain_files": ["renegadex.txt"]

--- a/cache_domains.json
+++ b/cache_domains.json
@@ -64,7 +64,7 @@
 		},
 		{
 			"name": "pathofexile",
-			"description": "Path Of Exile CDN",
+			"description": "CDN for Path Of Exile",
 			"domain_files": ["pathofexile.txt"]
 		},
 		{

--- a/pathofexile.txt
+++ b/pathofexile.txt
@@ -1,0 +1,1 @@
+patchcdn.pathofexile.com


### PR DESCRIPTION
### What CDN does this PR relate to
[Path Of Exile](https://www.pathofexile.com)

### Does this require running via sniproxy
no, because http traffic is supported by the CDN.

### Capture method
dns sniffer.

### Testing Scenario
at home.

### Testing Configuration
unbound config:
```
server:
  local-zone: "patchcdn.pathofexile.com" redirect
  local-data: "patchcdn.pathofexile.com 30 IN A 10.0.0.99"
```

### Sniproxy output
no output.

but here're couple nginx logs:
```
[patchcdn.pathofexile.com] 10.0.0.6 / - - patch [27/Apr/2020:12:13:37 +0100] "GET /3.10.1.4/minimap/Metadata_Terrain_Ledge_WalkableEdgeToWater_Scan.dds HTTP/1.1" 200 126979 "-" "-" "MISS" "patchcdn.pathofexile.com" "-"
[patchcdn.pathofexile.com] 10.0.0.6 / - - patch [27/Apr/2020:12:13:37 +0100] "GET /3.10.1.4/Art/Models/Items/Armours/Helmets/Uniques/StitchedDemonMask/StitchedDemonMaskHelmetDexInt.sm HTTP/1.1" 200 586 "-" "-" "MISS" "patchcdn.pathofexile.com" "-"
[patchcdn.pathofexile.com] 10.0.0.6 / - - patch [27/Apr/2020:12:13:37 +0100] "GET /3.10.1.4/Art/Textures/Doodads/Act5/Skullsns.dds HTTP/1.1" 200 80042 "-" "-" "MISS" "patchcdn.pathofexile.com" "-"
[patchcdn.pathofexile.com] 10.0.0.6 / - - patch [27/Apr/2020:12:13:37 +0100] "GET /3.10.1.4/Art/Microtransactions/Misc/fireworks/yellow_fw_streaks.dds HTTP/1.1" 200 64897 "-" "-" "MISS" "patchcdn.pathofexile.com" "-"
```

