### PR TITLE
Refactor Dnsmasq script to support multiple cache ips

### DIFF
--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -42,7 +42,7 @@ while read -r entry; do
         cacheip=$(jq -r 'if type == "array" then .[] else . end' <<< ${!cacheipname} | xargs)
         while read -r fileid; do
                 while read -r filename; do
-                        destfilename=$(echo $filename | sed -e 's/txt/conf/')
+                        destfilename=$(echo $filename | sed -e 's/txt/hosts/')
                         outputfile=${outputdir}/${destfilename}
                         touch "$outputfile"
                         while read -r fileentry; do
@@ -55,7 +55,7 @@ while read -r entry; do
                                         continue
                                 fi
                                 for i in ${cacheip}; do
-                                        echo "address=/${parsed}/${i}" >> "$outputfile"
+                                        echo "${i} ${parsed}" >> "$outputfile"
                                 done
                         done <<< $(cat ${basedir}/$filename);
                 done <<< $(jq -r ".cache_domains[$entry].domain_files[$fileid]" $path)

--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -27,6 +27,7 @@ done <<< $(jq -r '.cache_domains | to_entries[] | .key' config.json)
 
 rm -rf ${outputdir}
 mkdir -p ${outputdir}
+touch ${outputdir}/lancache.conf
 while read -r entry; do
         unset cacheip
         unset cachename
@@ -44,6 +45,7 @@ while read -r entry; do
                 while read -r filename; do
                         destfilename=$(echo $filename | sed -e 's/txt/hosts/')
                         outputfile=${outputdir}/${destfilename}
+                        echo "addn-hosts=/etc/dnsmasq.d/${destfilename}" >> ${outputdir}/lancache.conf
                         touch "$outputfile"
                         while read -r fileentry; do
                                 # Ignore comments


### PR DESCRIPTION
This change is a continuation of #54, it modifies the output of the dnsmasq script to host file format which allows round robin DNS entries.

There is a caveat with round robin DNS entries in dnsmasq, they only supports a single address for wildcard domains, for example: *.cdn.blizzard.com.

If previously you had the generated .conf files dumped into a directory where dnsmasq automatically loaded on start-up, you will need to create config that loads all the host files, for example:

**lancache.conf**
```conf
addn-hosts=/etc/dnsmasq.d/blizzard.hosts
addn-hosts=/etc/dnsmasq.d/steam.hosts
addn-hosts=/etc/dnsmasq.d/uplay.hosts
```

Closes #107.