### PR TITLE
Fix generation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 scripts/output
+scripts/config.json

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ You can use this list one of two ways:
  - Overriding DNS for these hostnames to point to the IP of your cache server.
  - Use them in Squid with WCCP to redirect content to the right cache server.
 
-There is a cache_domains.json file to define CDNs and additional meta deta with the following structure
+There is a cache_domains.json file to define CDNs and additional metadata with the following structure
 
 - cache_domains: Array of cache_domain object
     - name: shortname for the cache domain. Should match `^[0-9A-Za-z]$`
     - description: a longer description to aid others in identifying what this domain does (not all users of this repo will want to enable all caches)
     - notes: implementation specific notes which may be useful for other users
-    - domain_files: array of files within the repo assosciated to the cdn. Most cdn's only need one file
+    - domain_files: array of files within the repo associated to the cdn. Most CDNs only need one file
     - Example domain entry for steam
 ```json
 {
@@ -35,7 +35,7 @@ There is a cache_domains.json file to define CDNs and additional meta deta with 
 
 There is a separate file for each cacheable service. Some notes on formatting:
 
-  - Every line should be a seperate hostname for that service.
+  - Every line should be a separate hostname for that service.
   - Only one entry is permitted per line.
   - Wildcards are permitted as per below
   - Lines starting with a # will be treated as a comment.
@@ -46,10 +46,10 @@ There is a separate file for each cacheable service. Some notes on formatting:
 
 The wildcard format shall be defined as per the below
 
-  - Wildcards should be represented with an asterix.
+  - Wildcards should be represented with an asterisk.
   - If a wildcard is used, it should be the first character on the line.
   - Wildcards are not treated as matching null, e.g. `*.example.com` will match `a.example.com` but will not match `example.com`
-  - Only simple domain wildcards will be accepted eg `*.example.com` not `*ww.example.com`
+  - Only simple domain wildcards will be accepted e.g. `*.example.com` not `*ww.example.com`
 
 ##### Notes for Squid users
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,4 +46,4 @@ The `lancache.conf` should be copied into the `/etc/dnsmasq.d/` location but als
 You can copy the `*.hosts` file to any location other than `/etc/dnsmasq.d/` as this location is utilised only for `*.conf` files.
 
 For example if utilising Pi-hole a user can copy the `*.hosts` files to `/etc/pihole/` and modify the `lancache.conf` with the following command, prior to copying it to `/etc/dnsmasq.d/`:
-`sed -i 's/dnsmasq.d/pihole/g' output/dnsmasq/lancache.conf`
+`sed -i 's/dnsmasq\/hosts/pihole/g' output/dnsmasq/lancache.conf`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,49 @@
+# DNS Generation Scripts
+
+## Introduction
+
+The respective shell scripts contained within this directory can be utilised to generate application specific compliant
+configuration which can be utilised with:
+
+* Dnsmasq
+* Unbound
+
+## Usage
+
+1. Copy `config.example.json` to `config.json`.
+2. Modify `config.json` to include your Cacheserver's IP(s) and the CDNs you plan to cache.
+   The following example assumes a single shared Cacheserver IP:
+```json
+{
+  "ips": {
+    "generic":	["10.10.10.200"]
+  },
+  "cache_domains": {
+    "blizzard":     "generic",
+    "epicgames":    "generic",
+    "nintendo":     "generic",
+    "origin":       "generic",
+    "riot":         "generic",
+    "sony":         "generic",
+    "steam":        "generic",
+    "uplay":        "generic",
+    "wsus":         "generic"
+  }
+}
+```
+3. Run generation script relative to your DNS implementation: `bash create-dnsmasq.sh`.
+4. Copy files from `output/{dnsmasq,unbound}/*` to the respective locations for Dnsmasq/Unbound.
+5. Restart Dnsmasq or Unbound.
+
+### Notes for Dnsmasq users
+
+**This also applies to users utilising the script alongside Pi-hole.**
+
+If utilising the `create-dnsmasq.sh` the generation script will create a `lancache.conf` which also loads in the respective `*.hosts` files.
+
+The `lancache.conf` should be copied into the `/etc/dnsmasq.d/` location but also will need to be modified to point to the respective location of the `*.hosts` files.
+
+You can copy the `*.hosts` file to any location other than `/etc/dnsmasq.d/` as this location is utilised only for `*.conf` files.
+
+For example if utilising Pi-hole a user can copy the `*.hosts` files to `/etc/pihole/` and modify the `lancache.conf` with the following command, prior to copying it to `/etc/dnsmasq.d/`:
+`sed -i 's/dnsmasq.d/pihole/g' output/dnsmasq/lancache.conf`

--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -26,7 +26,7 @@ while read -r line; do
 done <<< $(jq -r '.cache_domains | to_entries[] | .key' config.json)
 
 rm -rf ${outputdir}
-mkdir -p ${outputdir}
+mkdir -p ${outputdir}/hosts
 touch ${outputdir}/lancache.conf
 while read -r entry; do
         unset cacheip
@@ -45,8 +45,8 @@ while read -r entry; do
                 while read -r filename; do
                         destfilename=$(echo $filename | sed -e 's/txt/hosts/')
                         lancacheconf=${outputdir}/lancache.conf
-                        outputfile=${outputdir}/${destfilename}
-                        echo "addn-hosts=/etc/dnsmasq/${destfilename}" >> ${lancacheconf}
+                        outputfile=${outputdir}/hosts/${destfilename}
+                        echo "addn-hosts=/etc/dnsmasq/hosts/${destfilename}" >> ${lancacheconf}
                         touch "$outputfile"
                         # Wildcard entries
                         while read -r fileentry; do

--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -79,3 +79,5 @@ while read -r entry; do
                 done <<< $(jq -r ".cache_domains[$entry].domain_files[$fileid]" $path)
         done <<< $(jq -r ".cache_domains[$entry].domain_files | to_entries[] | .key" $path)
 done <<< $(jq -r '.cache_domains | to_entries[] | .key' $path)
+
+echo "Please copy the following files:\n- ./output/dnsmasq/lancache.conf to /etc/dnsmasq/dnsmasq.d/\n- ./output/dnsmasq/hosts to /etc/dnsmasq/"

--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -46,7 +46,7 @@ while read -r entry; do
                         destfilename=$(echo $filename | sed -e 's/txt/hosts/')
                         lancacheconf=${outputdir}/lancache.conf
                         outputfile=${outputdir}/${destfilename}
-                        echo "addn-hosts=/etc/dnsmasq.d/${destfilename}" >> ${lancacheconf}
+                        echo "addn-hosts=/etc/dnsmasq/${destfilename}" >> ${lancacheconf}
                         touch "$outputfile"
                         # Wildcard entries
                         while read -r fileentry; do

--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -50,32 +50,32 @@ while read -r entry; do
                         touch "$outputfile"
                         # Wildcard entries
                         while read -r fileentry; do
-                                # Ignore comments
-                                if [[ $fileentry == \#* ]]; then
+                                # Ignore comments and non-wildcards
+                                if [[ $fileentry == \#* ]] || [[ ! $fileentry =~ ^\*\. ]]; then
                                         continue
                                 fi
-                                wildcard=$(echo $fileentry | grep "*." | sed -e "s/^\*\.//")
-                                if grep -q "$wildcard" "$lancacheconf"; then
+                                wildcard=$(echo $fileentry | sed -e "s/^\*\.//")
+                                if grep -qx "$wildcard" "$lancacheconf"; then
                                         continue
                                 fi
                                 for i in ${cacheip}; do
                                         echo "address=/${wildcard}/${i}" >> "$lancacheconf"
                                 done
-                        done <<< $(cat ${basedir}/$filename);
+                        done <<< $(cat ${basedir}/$filename | sort);
                         # All other entries
                         while read -r fileentry; do
-                                # Ignore comments
-                                if [[ $fileentry == \#* ]]; then
+                                # Ignore comments and wildcards
+                                if [[ $fileentry =~ ^(\#|\*\.) ]]; then
                                         continue
                                 fi
-                                parsed=$(echo $fileentry | sed -e "s/^\*\.//")
-                                if grep -q "$parsed" "$outputfile"; then
+                                parsed=$(echo $fileentry)
+                                if grep -qx "$parsed" "$outputfile"; then
                                         continue
                                 fi
                                 for i in ${cacheip}; do
                                         echo "${i} ${parsed}" >> "$outputfile"
                                 done
-                        done <<< $(cat ${basedir}/$filename);
+                        done <<< $(cat ${basedir}/$filename | sort);
                 done <<< $(jq -r ".cache_domains[$entry].domain_files[$fileid]" $path)
         done <<< $(jq -r ".cache_domains[$entry].domain_files | to_entries[] | .key" $path)
 done <<< $(jq -r '.cache_domains | to_entries[] | .key' $path)

--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -80,4 +80,10 @@ while read -r entry; do
         done <<< $(jq -r ".cache_domains[$entry].domain_files | to_entries[] | .key" $path)
 done <<< $(jq -r '.cache_domains | to_entries[] | .key' $path)
 
-echo "Please copy the following files:\n- ./output/dnsmasq/lancache.conf to /etc/dnsmasq/dnsmasq.d/\n- ./output/dnsmasq/hosts to /etc/dnsmasq/"
+cat << EOF
+Configuration generation completed.
+
+Please copy the following files:
+- ./${outputdir}/lancache.conf to /etc/dnsmasq/dnsmasq.d/
+- ./${outputdir}/hosts to /etc/dnsmasq/
+EOF

--- a/scripts/create-unbound.sh
+++ b/scripts/create-unbound.sh
@@ -52,14 +52,14 @@ while read entry; do
 					continue
 				fi
 				parsed=$(echo $fileentry | sed -e "s/^\*\.//")
-				if grep -q "$parsed" $outputfile; then
+				if grep -qx "$parsed" $outputfile; then
 					continue
 				fi
 				echo "  local-zone: \"${parsed}\" redirect" >> $outputfile
 				for i in ${cacheip}; do
 					echo "  local-data: \"${parsed} 30 IN A ${i}\"" >> $outputfile
 				done
-			done <<< $(cat ${basedir}/$filename);
+			done <<< $(cat ${basedir}/$filename | sort);
 		done <<< $(jq -r ".cache_domains[$entry].domain_files[$fileid]" $path)
 	done <<< $(jq -r ".cache_domains[$entry].domain_files | to_entries[] | .key" $path)
 done <<< $(jq -r '.cache_domains | to_entries[] | .key' $path)

--- a/scripts/create-unbound.sh
+++ b/scripts/create-unbound.sh
@@ -63,3 +63,10 @@ while read entry; do
 		done <<< $(jq -r ".cache_domains[$entry].domain_files[$fileid]" $path)
 	done <<< $(jq -r ".cache_domains[$entry].domain_files | to_entries[] | .key" $path)
 done <<< $(jq -r '.cache_domains | to_entries[] | .key' $path)
+
+cat << EOF
+Configuration generation completed.
+
+Please copy the following files:
+- ./${outputdir}/*.conf to /etc/unbound/unbound.conf.d/
+EOF


### PR DESCRIPTION
This change leverages #130 and also applies this to the dnsmasq script.

As it currently stands both generation scripts (unbound and dnsmasq) have a condition where a domain will be skipped if it fuzzy matches a domain already parsed that is higher in the CDN domain list.

For example the latter of the below two samples would never be added.
https://github.com/uklans/cache-domains/blob/8793ce15315cac1e594f7602158c2e82f510bc91/steam.txt#L20 https://github.com/uklans/cache-domains/blob/8793ce15315cac1e594f7602158c2e82f510bc91/steam.txt#L29

I've also taken the liberty to sort the output of said scripts for readability and troubleshooting purposes.

Example outputs of each script before this commit and after are provided below.

For context the Steam CDN currently has 51 entries of which 9 are wildcards.
dnsmasq needs to cater for wildcards in the `lancache.conf` and all other hosts in the respective CDN's output `.hosts` file, so this should be a 9 (wildcard) + 42 (non-wildcard) host split:

**[dnsmasq] `lancache.conf` before:
(9 unsorted wildcard entries and .hosts ref)**
```conf
addn-hosts=/etc/dnsmasq.d/steam.hosts
address=/content.steampowered.com/10.10.10.200
address=/hsar.steampowered.com.edgesuite.net/10.10.10.200
address=/akamai.steamstatic.com/10.10.10.200
address=/cs.steampowered.com/10.10.10.200
address=/cm.steampowered.com/10.10.10.200
address=/edgecast.steamstatic.com/10.10.10.200
address=/steamcontent.com/10.10.10.200
address=/steam-content-dnld-1.apac-1-cdn.cqloud.com/10.10.10.200
address=/steam-content-dnld-1.eu-c1-cdn.cqloud.com/10.10.10.200
```

**[dnsmasq] `lancache.conf` after:
(9 sorted wildcard entries and .hosts ref)**
```conf
addn-hosts=/etc/dnsmasq.d/steam.hosts
address=/akamai.steamstatic.com/10.10.10.200
address=/cm.steampowered.com/10.10.10.200
address=/content.steampowered.com/10.10.10.200
address=/cs.steampowered.com/10.10.10.200
address=/edgecast.steamstatic.com/10.10.10.200
address=/hsar.steampowered.com.edgesuite.net/10.10.10.200
address=/steamcontent.com/10.10.10.200
address=/steam-content-dnld-1.apac-1-cdn.cqloud.com/10.10.10.200
address=/steam-content-dnld-1.eu-c1-cdn.cqloud.com/10.10.10.200
```

**[dnsmasq] `steam.hosts` before:
(46 unsorted entries, missing fuzzy matches and not properly excluding wildcards)**
```hosts
10.10.10.200 lancache.steamcontent.com
10.10.10.200 content.steampowered.com
10.10.10.200 content1.steampowered.com
10.10.10.200 content2.steampowered.com
10.10.10.200 content3.steampowered.com
10.10.10.200 content4.steampowered.com
10.10.10.200 content5.steampowered.com
10.10.10.200 content6.steampowered.com
10.10.10.200 content7.steampowered.com
10.10.10.200 content8.steampowered.com
10.10.10.200 cs.steampowered.com
10.10.10.200 client-download.steampowered.com
10.10.10.200 hsar.steampowered.com.edgesuite.net
10.10.10.200 akamai.steamstatic.com
10.10.10.200 content-origin.steampowered.com
10.10.10.200 clientconfig.akamai.steamtransparent.com
10.10.10.200 steampipe.akamaized.net
10.10.10.200 edgecast.steamstatic.com
10.10.10.200 steam.apac.qtlglb.com.mwcloudcdn.com
10.10.10.200 cm.steampowered.com
10.10.10.200 cdn1-sea1.valve.net
10.10.10.200 cdn2-sea1.valve.net
10.10.10.200 steam-content-dnld-1.apac-1-cdn.cqloud.com
10.10.10.200 steam-content-dnld-1.eu-c1-cdn.cqloud.com
10.10.10.200 edge.steam-dns.top.comcast.net
10.10.10.200 edge.steam-dns-2.top.comcast.net
10.10.10.200 steam.naeu.qtlglb.com
10.10.10.200 steampipe-kr.akamaized.net
10.10.10.200 steam.ix.asn.au
10.10.10.200 steam.eca.qtlglb.com
10.10.10.200 steam.cdn.on.net
10.10.10.200 update5.dota2.wmsj.cn
10.10.10.200 update2.dota2.wmsj.cn
10.10.10.200 update6.dota2.wmsj.cn
10.10.10.200 update3.dota2.wmsj.cn
10.10.10.200 update1.dota2.wmsj.cn
10.10.10.200 update4.dota2.wmsj.cn
10.10.10.200 update5.csgo.wmsj.cn
10.10.10.200 update2.csgo.wmsj.cn
10.10.10.200 update4.csgo.wmsj.cn
10.10.10.200 update3.csgo.wmsj.cn
10.10.10.200 update6.csgo.wmsj.cn
10.10.10.200 update1.csgo.wmsj.cn
10.10.10.200 st.dl.bscstorage.net
10.10.10.200 cdn.mileweb.cs.steampowered.com.8686c.com
10.10.10.200 steamcdn-a.akamaihd.net
```

**[dnsmasq] `steam.hosts` after:
(42 sorted entries, only includes non-wildcard entries as intended and picks up fuzzy matches)**
```hosts
10.10.10.200 cdn1-sea1.valve.net
10.10.10.200 cdn2-sea1.valve.net
10.10.10.200 cdn.mileweb.cs.steampowered.com.8686c.com
10.10.10.200 clientconfig.akamai.steamtransparent.com
10.10.10.200 client-download.steampowered.com
10.10.10.200 content1.steampowered.com
10.10.10.200 content2.steampowered.com
10.10.10.200 content3.steampowered.com
10.10.10.200 content4.steampowered.com
10.10.10.200 content5.steampowered.com
10.10.10.200 content6.steampowered.com
10.10.10.200 content7.steampowered.com
10.10.10.200 content8.steampowered.com
10.10.10.200 content-origin.steampowered.com
10.10.10.200 cs.steampowered.com
10.10.10.200 edgecast.steamstatic.com
10.10.10.200 edge.steam-dns-2.top.comcast.net
10.10.10.200 edge.steam-dns.top.comcast.net
10.10.10.200 lancache.steamcontent.com
10.10.10.200 st.dl.bscstorage.net
10.10.10.200 steam.apac.qtlglb.com
10.10.10.200 steam.apac.qtlglb.com.mwcloudcdn.com
10.10.10.200 steamcdn-a.akamaihd.net
10.10.10.200 steam.cdn.on.net
10.10.10.200 steamcontent.com
10.10.10.200 steam.eca.qtlglb.com
10.10.10.200 steam.ix.asn.au
10.10.10.200 steam.naeu.qtlglb.com
10.10.10.200 steampipe.akamaized.net
10.10.10.200 steampipe-kr.akamaized.net
10.10.10.200 update1.csgo.wmsj.cn
10.10.10.200 update1.dota2.wmsj.cn
10.10.10.200 update2.csgo.wmsj.cn
10.10.10.200 update2.dota2.wmsj.cn
10.10.10.200 update3.csgo.wmsj.cn
10.10.10.200 update3.dota2.wmsj.cn
10.10.10.200 update4.csgo.wmsj.cn
10.10.10.200 update4.dota2.wmsj.cn
10.10.10.200 update5.csgo.wmsj.cn
10.10.10.200 update5.dota2.wmsj.cn
10.10.10.200 update6.csgo.wmsj.cn
10.10.10.200 update6.dota2.wmsj.cn
```

**[unbound] `steam.conf` before:
(46 unsorted entries, missing fuzzy matches)**
```conf
server:
  local-zone: "lancache.steamcontent.com" redirect
  local-data: "lancache.steamcontent.com 30 IN A 10.10.10.200"
  local-zone: "content.steampowered.com" redirect
  local-data: "content.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content1.steampowered.com" redirect
  local-data: "content1.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content2.steampowered.com" redirect
  local-data: "content2.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content3.steampowered.com" redirect
  local-data: "content3.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content4.steampowered.com" redirect
  local-data: "content4.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content5.steampowered.com" redirect
  local-data: "content5.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content6.steampowered.com" redirect
  local-data: "content6.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content7.steampowered.com" redirect
  local-data: "content7.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content8.steampowered.com" redirect
  local-data: "content8.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "cs.steampowered.com" redirect
  local-data: "cs.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "client-download.steampowered.com" redirect
  local-data: "client-download.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "hsar.steampowered.com.edgesuite.net" redirect
  local-data: "hsar.steampowered.com.edgesuite.net 30 IN A 10.10.10.200"
  local-zone: "akamai.steamstatic.com" redirect
  local-data: "akamai.steamstatic.com 30 IN A 10.10.10.200"
  local-zone: "content-origin.steampowered.com" redirect
  local-data: "content-origin.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "clientconfig.akamai.steamtransparent.com" redirect
  local-data: "clientconfig.akamai.steamtransparent.com 30 IN A 10.10.10.200"
  local-zone: "steampipe.akamaized.net" redirect
  local-data: "steampipe.akamaized.net 30 IN A 10.10.10.200"
  local-zone: "edgecast.steamstatic.com" redirect
  local-data: "edgecast.steamstatic.com 30 IN A 10.10.10.200"
  local-zone: "steam.apac.qtlglb.com.mwcloudcdn.com" redirect
  local-data: "steam.apac.qtlglb.com.mwcloudcdn.com 30 IN A 10.10.10.200"
  local-zone: "cm.steampowered.com" redirect
  local-data: "cm.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "cdn1-sea1.valve.net" redirect
  local-data: "cdn1-sea1.valve.net 30 IN A 10.10.10.200"
  local-zone: "cdn2-sea1.valve.net" redirect
  local-data: "cdn2-sea1.valve.net 30 IN A 10.10.10.200"
  local-zone: "steam-content-dnld-1.apac-1-cdn.cqloud.com" redirect
  local-data: "steam-content-dnld-1.apac-1-cdn.cqloud.com 30 IN A 10.10.10.200"
  local-zone: "steam-content-dnld-1.eu-c1-cdn.cqloud.com" redirect
  local-data: "steam-content-dnld-1.eu-c1-cdn.cqloud.com 30 IN A 10.10.10.200"
  local-zone: "edge.steam-dns.top.comcast.net" redirect
  local-data: "edge.steam-dns.top.comcast.net 30 IN A 10.10.10.200"
  local-zone: "edge.steam-dns-2.top.comcast.net" redirect
  local-data: "edge.steam-dns-2.top.comcast.net 30 IN A 10.10.10.200"
  local-zone: "steam.naeu.qtlglb.com" redirect
  local-data: "steam.naeu.qtlglb.com 30 IN A 10.10.10.200"
  local-zone: "steampipe-kr.akamaized.net" redirect
  local-data: "steampipe-kr.akamaized.net 30 IN A 10.10.10.200"
  local-zone: "steam.ix.asn.au" redirect
  local-data: "steam.ix.asn.au 30 IN A 10.10.10.200"
  local-zone: "steam.eca.qtlglb.com" redirect
  local-data: "steam.eca.qtlglb.com 30 IN A 10.10.10.200"
  local-zone: "steam.cdn.on.net" redirect
  local-data: "steam.cdn.on.net 30 IN A 10.10.10.200"
  local-zone: "update5.dota2.wmsj.cn" redirect
  local-data: "update5.dota2.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update2.dota2.wmsj.cn" redirect
  local-data: "update2.dota2.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update6.dota2.wmsj.cn" redirect
  local-data: "update6.dota2.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update3.dota2.wmsj.cn" redirect
  local-data: "update3.dota2.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update1.dota2.wmsj.cn" redirect
  local-data: "update1.dota2.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update4.dota2.wmsj.cn" redirect
  local-data: "update4.dota2.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update5.csgo.wmsj.cn" redirect
  local-data: "update5.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update2.csgo.wmsj.cn" redirect
  local-data: "update2.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update4.csgo.wmsj.cn" redirect
  local-data: "update4.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update3.csgo.wmsj.cn" redirect
  local-data: "update3.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update6.csgo.wmsj.cn" redirect
  local-data: "update6.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update1.csgo.wmsj.cn" redirect
  local-data: "update1.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "st.dl.bscstorage.net" redirect
  local-data: "st.dl.bscstorage.net 30 IN A 10.10.10.200"
  local-zone: "cdn.mileweb.cs.steampowered.com.8686c.com" redirect
  local-data: "cdn.mileweb.cs.steampowered.com.8686c.com 30 IN A 10.10.10.200"
  local-zone: "steamcdn-a.akamaihd.net" redirect
  local-data: "steamcdn-a.akamaihd.net 30 IN A 10.10.10.200"
```

**[unbound] `steam.conf` after:
(51 sorted entries, picks up fuzzy matches)**
```hosts
server:
  local-zone: "akamai.steamstatic.com" redirect
  local-data: "akamai.steamstatic.com 30 IN A 10.10.10.200"
  local-zone: "cdn1-sea1.valve.net" redirect
  local-data: "cdn1-sea1.valve.net 30 IN A 10.10.10.200"
  local-zone: "cdn2-sea1.valve.net" redirect
  local-data: "cdn2-sea1.valve.net 30 IN A 10.10.10.200"
  local-zone: "cdn.mileweb.cs.steampowered.com.8686c.com" redirect
  local-data: "cdn.mileweb.cs.steampowered.com.8686c.com 30 IN A 10.10.10.200"
  local-zone: "clientconfig.akamai.steamtransparent.com" redirect
  local-data: "clientconfig.akamai.steamtransparent.com 30 IN A 10.10.10.200"
  local-zone: "client-download.steampowered.com" redirect
  local-data: "client-download.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "cm.steampowered.com" redirect
  local-data: "cm.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content1.steampowered.com" redirect
  local-data: "content1.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content2.steampowered.com" redirect
  local-data: "content2.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content3.steampowered.com" redirect
  local-data: "content3.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content4.steampowered.com" redirect
  local-data: "content4.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content5.steampowered.com" redirect
  local-data: "content5.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content6.steampowered.com" redirect
  local-data: "content6.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content7.steampowered.com" redirect
  local-data: "content7.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content8.steampowered.com" redirect
  local-data: "content8.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content-origin.steampowered.com" redirect
  local-data: "content-origin.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "content.steampowered.com" redirect
  local-data: "content.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "cs.steampowered.com" redirect
  local-data: "cs.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "cs.steampowered.com" redirect
  local-data: "cs.steampowered.com 30 IN A 10.10.10.200"
  local-zone: "edgecast.steamstatic.com" redirect
  local-data: "edgecast.steamstatic.com 30 IN A 10.10.10.200"
  local-zone: "edgecast.steamstatic.com" redirect
  local-data: "edgecast.steamstatic.com 30 IN A 10.10.10.200"
  local-zone: "edge.steam-dns-2.top.comcast.net" redirect
  local-data: "edge.steam-dns-2.top.comcast.net 30 IN A 10.10.10.200"
  local-zone: "edge.steam-dns.top.comcast.net" redirect
  local-data: "edge.steam-dns.top.comcast.net 30 IN A 10.10.10.200"
  local-zone: "hsar.steampowered.com.edgesuite.net" redirect
  local-data: "hsar.steampowered.com.edgesuite.net 30 IN A 10.10.10.200"
  local-zone: "lancache.steamcontent.com" redirect
  local-data: "lancache.steamcontent.com 30 IN A 10.10.10.200"
  local-zone: "st.dl.bscstorage.net" redirect
  local-data: "st.dl.bscstorage.net 30 IN A 10.10.10.200"
  local-zone: "steam.apac.qtlglb.com" redirect
  local-data: "steam.apac.qtlglb.com 30 IN A 10.10.10.200"
  local-zone: "steam.apac.qtlglb.com.mwcloudcdn.com" redirect
  local-data: "steam.apac.qtlglb.com.mwcloudcdn.com 30 IN A 10.10.10.200"
  local-zone: "steamcdn-a.akamaihd.net" redirect
  local-data: "steamcdn-a.akamaihd.net 30 IN A 10.10.10.200"
  local-zone: "steam.cdn.on.net" redirect
  local-data: "steam.cdn.on.net 30 IN A 10.10.10.200"
  local-zone: "steamcontent.com" redirect
  local-data: "steamcontent.com 30 IN A 10.10.10.200"
  local-zone: "steamcontent.com" redirect
  local-data: "steamcontent.com 30 IN A 10.10.10.200"
  local-zone: "steam-content-dnld-1.apac-1-cdn.cqloud.com" redirect
  local-data: "steam-content-dnld-1.apac-1-cdn.cqloud.com 30 IN A 10.10.10.200"
  local-zone: "steam-content-dnld-1.eu-c1-cdn.cqloud.com" redirect
  local-data: "steam-content-dnld-1.eu-c1-cdn.cqloud.com 30 IN A 10.10.10.200"
  local-zone: "steam.eca.qtlglb.com" redirect
  local-data: "steam.eca.qtlglb.com 30 IN A 10.10.10.200"
  local-zone: "steam.ix.asn.au" redirect
  local-data: "steam.ix.asn.au 30 IN A 10.10.10.200"
  local-zone: "steam.naeu.qtlglb.com" redirect
  local-data: "steam.naeu.qtlglb.com 30 IN A 10.10.10.200"
  local-zone: "steampipe.akamaized.net" redirect
  local-data: "steampipe.akamaized.net 30 IN A 10.10.10.200"
  local-zone: "steampipe-kr.akamaized.net" redirect
  local-data: "steampipe-kr.akamaized.net 30 IN A 10.10.10.200"
  local-zone: "update1.csgo.wmsj.cn" redirect
  local-data: "update1.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update1.dota2.wmsj.cn" redirect
  local-data: "update1.dota2.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update2.csgo.wmsj.cn" redirect
  local-data: "update2.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update2.dota2.wmsj.cn" redirect
  local-data: "update2.dota2.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update3.csgo.wmsj.cn" redirect
  local-data: "update3.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update3.dota2.wmsj.cn" redirect
  local-data: "update3.dota2.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update4.csgo.wmsj.cn" redirect
  local-data: "update4.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update4.dota2.wmsj.cn" redirect
  local-data: "update4.dota2.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update5.csgo.wmsj.cn" redirect
  local-data: "update5.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update5.dota2.wmsj.cn" redirect
  local-data: "update5.dota2.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update6.csgo.wmsj.cn" redirect
  local-data: "update6.csgo.wmsj.cn 30 IN A 10.10.10.200"
  local-zone: "update6.dota2.wmsj.cn" redirect
  local-data: "update6.dota2.wmsj.cn 30 IN A 10.10.10.200"
```

Closes #130.
Closes #155.
Closes #156.