### PR TITLE
Add new domain for xbox live while xbox is sleeping

### DIFF
--- a/xboxlive.txt
+++ b/xboxlive.txt
@@ -7,3 +7,4 @@ xboxone.vo.llnwd.net
 xbox-mbr.xboxlive.com
 assets1.xboxlive.com.nsatc.net
 xvcf1.xboxlive.com
+d1.xboxlive.com

--- a/xboxlive.txt
+++ b/xboxlive.txt
@@ -8,3 +8,4 @@ xbox-mbr.xboxlive.com
 assets1.xboxlive.com.nsatc.net
 xvcf1.xboxlive.com
 d1.xboxlive.com
+


### PR DESCRIPTION
### What CDN does this PR relate to
Xbox one downloads when console is in instant on mode and sleeping

### Does this require running via sniproxy
Untested

### Capture method
Wireshark capture through windows 10 hotspot. filtering dns requests as the xbox turned off and monitored when the download started on the router

### Testing Scenario
home scenario, started game download on the xbox while monitoring router traffic. Showed download was to the lancache. When the xbox powered off a new download started direct from the xbox. After updating the git the download continued on lancache when the xbox went to sleep. nslookup confirmed new domain redirected to lancache

### Testing Configuration
Using docker compose. Added CACHE_DOMAINS_REPO to .env file and used custom fork


