### PR TITLE
Update steam.txt

### DIFF
--- a/steam.txt
+++ b/steam.txt
@@ -27,8 +27,10 @@ cdn2-sea1.valve.net
 162-254-198-14.valve.net
 162-254-198-17.valve.net
 162-254-198-18.valve.net
+162-254-198-19.valve.net
 162-254-198-78.valve.net
 162-254-198-81.valve.net
+162-254-198-82.valve.net
 162-254-198-83.valve.net
 162-254-198-131.valve.net
 *.steam-content-dnld-1.apac-1-cdn.cqloud.com

--- a/steam.txt
+++ b/steam.txt
@@ -25,6 +25,8 @@ steam.apac.qtlglb.com.mwcloudcdn.com
 cdn1-sea1.valve.net
 cdn2-sea1.valve.net
 162-254-198-14.valve.net
+162-254-198-17.valve.net
+162-254-198-18.valve.net
 162-254-198-78.valve.net
 162-254-198-131.valve.net
 *.steam-content-dnld-1.apac-1-cdn.cqloud.com

--- a/steam.txt
+++ b/steam.txt
@@ -28,6 +28,8 @@ cdn2-sea1.valve.net
 162-254-198-17.valve.net
 162-254-198-18.valve.net
 162-254-198-78.valve.net
+162-254-198-81.valve.net
+162-254-198-83.valve.net
 162-254-198-131.valve.net
 *.steam-content-dnld-1.apac-1-cdn.cqloud.com
 *.steam-content-dnld-1.eu-c1-cdn.cqloud.com

--- a/steam.txt
+++ b/steam.txt
@@ -24,6 +24,9 @@ steam.apac.qtlglb.com.mwcloudcdn.com
 *.steamcontent.com
 cdn1-sea1.valve.net
 cdn2-sea1.valve.net
+162-254-198-14.valve.net
+162-254-198-78.valve.net
+162-254-198-131.valve.net
 *.steam-content-dnld-1.apac-1-cdn.cqloud.com
 *.steam-content-dnld-1.eu-c1-cdn.cqloud.com
 steam.apac.qtlglb.com


### PR DESCRIPTION
### What CDN does this PR relate to
Steam

### Does this require running via sniproxy
No

### Capture method
iftop on the dns server

### Testing Scenario
Download tekken 7 from steam while near the sweden servers (Only game that seems to have these)

### Testing Configuration
https://github.com/lancachenet/docker-compose

### Sniproxy output
```
    144 cache10-sto2.steamcontent.com
    529 cache1-sto1.steamcontent.com
    451 cache2-sto1.steamcontent.com
     25 cache3-sto1.steamcontent.com
    207 cache3-sto2.steamcontent.com
    155 cache4-sto2.steamcontent.com
    167 cache5-sto2.steamcontent.com
     24 cache6-fra1.steamcontent.com
    132 cache6-sto2.steamcontent.com
     99 cache7-sto1.steamcontent.com
     79 cache8-sto1.steamcontent.com
    142 cache9-sto2.steamcontent.com
      1 cm2-sto1.cm.steampowered.com
     76 level3.cdn.steampipe.steamcontent.com
      1 receive-lp1.dg.srv.nintendo.net
      9 steamcdn-a.akamaihd.net
```

