### PR TITLE
create-unbound.sh and create-dnsmasq.sh will now ignore empty entries…

### DIFF
--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -69,6 +69,10 @@ while read -r entry; do
                                         continue
                                 fi
                                 parsed=$(echo $fileentry)
+                                # Ignore empty lines
+                                if [[ -z "$parsed" ]]; then
+                                    continue
+                                fi
                                 if grep -qx "$parsed" "$outputfile"; then
                                         continue
                                 fi

--- a/scripts/create-unbound.sh
+++ b/scripts/create-unbound.sh
@@ -42,6 +42,7 @@ while read entry; do
 	cacheip=$(jq -r 'if type == "array" then .[] else . end' <<< ${!cacheipname} | xargs)
 	while read fileid; do
 		while read filename; do
+            isvalid=false
 			destfilename=$(echo $filename | sed -e 's/txt/conf/')
 			outputfile=${outputdir}/${destfilename}
 			touch $outputfile
@@ -52,14 +53,23 @@ while read entry; do
 					continue
 				fi
 				parsed=$(echo $fileentry | sed -e "s/^\*\.//")
+                # Ignore empty lines
+                if [[ -z "$parsed" ]]; then
+                    continue
+                fi
 				if grep -qx "$parsed" $outputfile; then
 					continue
 				fi
+                isvalid=true
 				echo "  local-zone: \"${parsed}\" redirect" >> $outputfile
 				for i in ${cacheip}; do
 					echo "  local-data: \"${parsed} 30 IN A ${i}\"" >> $outputfile
 				done
 			done <<< $(cat ${basedir}/$filename | sort);
+            # Delete files with no entries
+            if [[ $isvalid == false ]]; then
+                rm $outputfile
+            fi
 		done <<< $(jq -r ".cache_domains[$entry].domain_files[$fileid]" $path)
 	done <<< $(jq -r ".cache_domains[$entry].domain_files | to_entries[] | .key" $path)
 done <<< $(jq -r '.cache_domains | to_entries[] | .key' $path)


### PR DESCRIPTION
…, which may result into corrupt config files causing at least unbound (and probably also dnsmasq) to fail starting up

### Suggested fix
Use https://github.com/uklans/cache-domains/pull/158#pullrequestreview-572801353 rather than my PR. It's more elegant code.

### Initial Bugreport & PR
https://github.com/uklans/cache-domains/issues/157

### What CDN does this PR relate to
<!-- Please clearly state what existing cdn this pr relates to, or which games if it's a new cdn -->

### Does this require running via sniproxy
<!-- Yes/no/untested -->

### Capture method
<!-- Please give a short description how you ascertained the updates to the domain files, wireshark, dns logs etc -->

### Testing Scenario
<!-- Please give a short description on how you have tested this and where (home, office, small lan, large lan etc) -->

### Testing Configuration
```
<!-- Paste either your docker run command from the DNS container OR explain how you have setup DNS zone files etc to test this issue -->
```

### Sniproxy output
Please paste the output from `docker logs <sniproxy container name/id> | sed 's/.*\:443 \[//;s/\].*//' | sort | uniq -c` below
```
<!-- If you are running sniproxy paste the output to the following command
docker logs <sniproxy container name/id> | sed 's/.*\:443 \[//;s/\].*//' | sort | uniq -c
-->
```

