### PR TITLE
Handle newlines in generation scripts

### DIFF
--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -64,8 +64,8 @@ while read -r entry; do
                         done <<< $(cat ${basedir}/$filename | sort);
                         # All other entries
                         while read -r fileentry; do
-                                # Ignore comments and wildcards
-                                if [[ $fileentry =~ ^(\#|\*\.) ]]; then
+                                # Ignore comments, newlines and wildcards
+                                if [[ $fileentry =~ ^(\#|\*\.) ]] || [[ -z $fileentry ]]; then
                                         continue
                                 fi
                                 parsed=$(echo $fileentry)

--- a/scripts/create-unbound.sh
+++ b/scripts/create-unbound.sh
@@ -45,16 +45,18 @@ while read entry; do
 			destfilename=$(echo $filename | sed -e 's/txt/conf/')
 			outputfile=${outputdir}/${destfilename}
 			touch $outputfile
-			echo "server:" >> $outputfile
 			while read fileentry; do
-				# Ignore comments
-				if [[ $fileentry == \#* ]]; then
+				# Ignore comments and newlines
+				if [[ $fileentry == \#* ]] || [[ -z $fileentry ]]; then
 					continue
 				fi
 				parsed=$(echo $fileentry | sed -e "s/^\*\.//")
 				if grep -qx "$parsed" $outputfile; then
 					continue
 				fi
+        if [[ $(head -n 1 $outputfile) != "server:" ]]; then
+            echo "server:" >> $outputfile
+        fi
 				echo "  local-zone: \"${parsed}\" redirect" >> $outputfile
 				for i in ${cacheip}; do
 					echo "  local-data: \"${parsed} 30 IN A ${i}\"" >> $outputfile


### PR DESCRIPTION
The generation scripts will now properly handle/ignore empty lines as this previously would cause issues with the generated Unbound output.

Fixes #157.
Closes #158.

