### PR TITLE
Update epicgames.txt and steam.txt

### DIFF
--- a/epicgames.txt
+++ b/epicgames.txt
@@ -8,3 +8,4 @@ download2.epicgames.com
 download3.epicgames.com
 download4.epicgames.com
 epicgames-download1.akamaized.net
+fastly-download.epicgames.com

--- a/steam.txt
+++ b/steam.txt
@@ -26,6 +26,7 @@ cdn1-sea1.valve.net
 cdn2-sea1.valve.net
 *.steam-content-dnld-1.apac-1-cdn.cqloud.com
 *.steam-content-dnld-1.eu-c1-cdn.cqloud.com
+*.steam-content-dnld-1.qwilted-cds.cqloud.com
 steam.apac.qtlglb.com
 edge.steam-dns.top.comcast.net
 edge.steam-dns-2.top.comcast.net


### PR DESCRIPTION
### What CDN does this PR relate to
Epic Games

### Does this require running via sniproxy
No

### Capture method
pihole dns logging, EpicGameLauncher.log
(excerpt)
[2021.05.22-12.56.56:236][ 24]LogBuildPatchServices: Build Config: BackupDirectory: 
[2021.05.22-12.56.56:236][ 24]LogBuildPatchServices: Build Config: CloudDirectories: http://download.epicgames.com/Builds/UnrealEngineLauncher/CloudDir
[2021.05.22-12.56.56:236][ 24]LogBuildPatchServices: Build Config: CloudDirectories: http://download2.epicgames.com/Builds/UnrealEngineLauncher/CloudDir
[2021.05.22-12.56.56:236][ 24]LogBuildPatchServices: Build Config: CloudDirectories: http://download3.epicgames.com/Builds/UnrealEngineLauncher/CloudDir
[2021.05.22-12.56.56:236][ 24]LogBuildPatchServices: Build Config: CloudDirectories: http://download4.epicgames.com/Builds/UnrealEngineLauncher/CloudDir
[2021.05.22-12.56.56:236][ 24]LogBuildPatchServices: Build Config: CloudDirectories: http://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/CloudDir
[2021.05.22-12.56.56:236][ 24]LogBuildPatchServices: Build Config: CloudDirectories: http://fastly-download.epicgames.com/Builds/UnrealEngineLauncher/CloudDir

### Testing Scenario
Home network solution tested.  Known game title on this is cloud directory is "Ghostbusters: The Video Game Remastered" downloaded from Epic.  Docker lancache and lancachedns containers updated using forked repo for cache domains, and lancache access.log observed during initial caching miss and then second download confirmed hit from cache. Prior to update, this game title does not touch the lancache.

### Testing Configuration
```
  lancache:
    image: lancachenet/monolithic:latest
    container_name: lancache
    network_mode: host
    ports:
      - 80:80/tcp
      - 443:443/tcp
    volumes:
      - /lancache/cache:/data/cache
      - /lancache/logs:/data/logs
    environment:
      - CACHE_MEM_SIZE=1500m
      - CACHE_DISK_SIZE=1000000m
      - CACHE_MAX_AGE=1780d
      - CACHE_DOMAINS_REPO=https://github.com/ukkev/cache-domains.git
      - UPSTREAM_DNS=8.8.8.8;1.1.1.1
      - TZ=${TZ}
    restart: unless-stopped

  lancache-dns:
    image: lancachenet/lancache-dns:latest
    container_name: lancache-dns
    network_mode: host
    ports:
      - "53:53/tcp"
      - "53:53/udp"
    environment:
      - USE_GENERIC_CACHE=true
      - LANCACHE_IP=192.168.20.6 192.168.20.7
      - CACHE_DOMAINS_REPO=https://github.com/ukkev/cache-domains.git
      - UPSTREAM_DNS=8.8.8.8;1.1.1.1
      - TZ=${TZ}
    restart: unless-stopped

```

### Sniproxy output
Please paste the output from `docker logs <sniproxy container name/id> | sed 's/.*\:443 \[//;s/\].*//' | sort | uniq -c` below
```
not using Sniproxy
```

