### PR TITLE
Add more Sony domains

### DIFF
--- a/origin.txt
+++ b/origin.txt
@@ -1,3 +1,2 @@
-# WARNING:  Origin has been seen downloading https client downloads on origin-a.akamaihd.net.  A solution should be in place to forward https to the origin server (eg sniproxy)
 origin-a.akamaihd.net
 lvlt.cdn.ea.com

--- a/sony.txt
+++ b/sony.txt
@@ -1,2 +1,15 @@
 gs2.ww.prod.dl.playstation.net
 gs2.sonycoment.loris-e.llnwd.net
+pls.patch.station.sony.com
+gs2.ww.prod.dl.playstation.net
+*.gs2.ww.prod.dl.playstation.net
+gs2.sonycoment.loris-e.llnwd.net
+*.gs2.sonycoment.loris-e.llnwd.net
+gs2-ww-prod.psn.akadns.net
+*.gs2-ww-prod.psn.akadns.net
+gs2.ww.prod.dl.playstation.net.edgesuite.net
+*.gs2.ww.prod.dl.playstation.net.edgesuite.net
+playstation4.sony.akadns.net
+theia.dl.playstation.net
+tmdb.np.dl.playstation.net
+gs-sec.ww.np.dl.playstation.net

--- a/sony.txt
+++ b/sony.txt
@@ -1,9 +1,7 @@
 gs2.ww.prod.dl.playstation.net
 gs2.sonycoment.loris-e.llnwd.net
 pls.patch.station.sony.com
-gs2.ww.prod.dl.playstation.net
 *.gs2.ww.prod.dl.playstation.net
-gs2.sonycoment.loris-e.llnwd.net
 *.gs2.sonycoment.loris-e.llnwd.net
 gs2-ww-prod.psn.akadns.net
 *.gs2-ww-prod.psn.akadns.net


### PR DESCRIPTION
### What CDN does this PR relate to
Sony

### Does this require running via sniproxy
No

### Capture method
Referenced https://github.com/uklans/cache-domains/issues/30 and confirmed using pihole + ntopng.

### Testing Scenario
Tested at home with multiple PS4s and PS5s.

### Testing Configuration
Fork of cache-domains running in lancache-dns.

### Sniproxy output
N/A. No TLS traffic during downloading, verified with ntopng.
