### PR TITLE
Remove reference to Twitch CDN

### DIFF
--- a/cache_domains.json
+++ b/cache_domains.json
@@ -108,11 +108,6 @@
 			"domain_files": ["teso.txt"]
 		},
 		{
-			"name": "twitch",
-			"description": "CDN for twitch games / mods and addons",
-			"domain_files": ["twitch.txt"]
-		},
-		{
 			"name": "warframe",
 			"description": "CDN for Warframe",
 			"domain_files": ["warframe.txt"]


### PR DESCRIPTION
Removing reference to Twitch CDN from `cache_domains.json`