### PR TITLE
Remove duplicates in Unbound generation script

### DIFF
--- a/scripts/create-unbound.sh
+++ b/scripts/create-unbound.sh
@@ -51,7 +51,7 @@ while read entry; do
 					continue
 				fi
 				parsed=$(echo $fileentry | sed -e "s/^\*\.//")
-				if grep -qx "$parsed" $outputfile; then
+				if grep -qx "  local-zone: \"${parsed}\" redirect" $outputfile; then
 					continue
 				fi
         if [[ $(head -n 1 $outputfile) != "server:" ]]; then


### PR DESCRIPTION
#149 introduced a minor regression which included duplicates for the Unbound generation script.
While this does not have a technical impact it may cause confusion for users, this PR will ignore duplicate entries.

Closes #163.