### PR TITLE
Revert Dnsmasq script breaking change

### DIFF
--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 basedir=".."
 outputdir="output/dnsmasq"
+outputfile="${outputdir}/lancache.conf"
 path="${basedir}/cache_domains.json"
 
 export IFS=' '
@@ -27,6 +28,7 @@ done <<< $(jq -r '.cache_domains | to_entries[] | .key' config.json)
 
 rm -rf ${outputdir}
 mkdir -p ${outputdir}
+touch ${outputfile}
 while read -r entry; do
         unset cacheip
         unset cachename
@@ -42,11 +44,8 @@ while read -r entry; do
         cacheip=$(jq -r 'if type == "array" then .[] else . end' <<< ${!cacheipname} | xargs)
         while read -r fileid; do
                 while read -r filename; do
-                        destfilename=$(echo $filename | sed -e 's/txt/conf/')
-                        outputfile=${outputdir}/${destfilename}
-                        touch ${outputfile}
                         while read -r fileentry; do
-                                # Ignore comments, newlines and wildcards
+                                # Ignore comments and newlines
                                 if [[ ${fileentry} == \#* ]] || [[ -z ${fileentry} ]]; then
                                         continue
                                 fi
@@ -65,6 +64,5 @@ done <<< $(jq -r '.cache_domains | to_entries[] | .key' ${path})
 cat << EOF
 Configuration generation completed.
 
-Please copy the following files:
-- ./${outputdir}/*.conf to /etc/dnsmasq/dnsmasq.d/
+Please copy ./${outputfile} to /etc/dnsmasq/dnsmasq.d/
 EOF


### PR DESCRIPTION
In https://github.com/uklans/cache-domains/pull/174 the output changed from a single `lancache.conf` to many variously named `.conf` files. Previously, It was only necessary to configure Dnsmasq with a single `lancache.conf` as the (also generated) `.hosts` files were referenced within. Since said pull request it is now necessary to configure Dnsmasq with N `.conf` files. 

This PR reverts this to only needing a single `lancache.conf` file.

I also can't see anything that the multiple `.conf` files afford us. I could see it providing an additional way of selectively disabling the caching of domain groups. But I'd argue that using the, `"cache_domains": { "steam": "disabled" }` way, or not having a `default` entry is still a better way. And was previously the only way for disabling wildcard domain groups.

