### PR TITLE
Remove additional newline

### DIFF
--- a/xboxlive.txt
+++ b/xboxlive.txt
@@ -8,4 +8,3 @@ xbox-mbr.xboxlive.com
 assets1.xboxlive.com.nsatc.net
 xvcf1.xboxlive.com
 d1.xboxlive.com
-


### PR DESCRIPTION
There's a single rogue newline that I noticed working on the DNS container.

This change ensures all the service `.txt` files only include a single newline at the end of the file.
