### PR TITLE
removed dlassets.microsoft.com

### DIFF
--- a/xboxlive.txt
+++ b/xboxlive.txt
@@ -1,6 +1,5 @@
 assets1.xboxlive.com
 assets2.xboxlive.com
-dlassets.xboxlive.com
 xboxone.loris.llnwd.net
 *.xboxone.loris.llnwd.net
 xboxone.vo.llnwd.net


### PR DESCRIPTION
### What CDN does this PR relate to
Xboxlive

### Does this require running via sniproxy
no

### Capture method
Crashed xbox Live Service pointing to dlassets.microsoft.com, checked in Logs of Lanchache DNS / Pihole DNS forwarder.

### Testing Scenario
Call was visible in both logs but not in Log of Monolithic container. Result is that the game ( Forza Horizon 5 ) was not able to start friend invites, since the GUI for this kept crashing ( C:\Program Files\WindowsApps\Microsoft.GamingServices_3.59.3001.0_x64__8wekyb3d8bbwe\TCUI-App.exe ) as long as the domain as forwarded.

### Testing Configuration
```
simple basic setup, run the basic DNS Container / Monolithic, configured for xboxlive, and try to invite a person from your friendlist in Forza Horizon 5, the Gui will crash. As soon as the DNS is not rerouted, the xboxlive module deactivated or the domain removed from the cache list, the problem will stop and the container will start to work again.
```
