### PR TITLE
Revert "Adds google, adobe and ms office domains"

### DIFF
--- a/adobe.txt
+++ b/adobe.txt
@@ -1,3 +1,0 @@
-ardownload.adobe.com
-ccmdl.adobe.com
-agsupdate.adobe.com

--- a/cache_domains.json
+++ b/cache_domains.json
@@ -6,11 +6,6 @@
 			"domain_files": ["arenanet.txt"]
 		},
 		{
-			"name": "adobe",
-			"description": "Adobe Updates",
-			"domain_files": ["adobe.txt"]
-		},
-		{
 			"name": "blizzard",
 			"description": "CDN for blizzard/battle.net",
 			"domain_files": ["blizzard.txt"]
@@ -39,11 +34,6 @@
 			"name": "frontier",
 			"description": "CDN for frontier games",
 			"domain_files": ["frontier.txt"]
-		},
-		{
-			"name": "google",
-			"description": "Chrome and Google Updates",
-			"domain_files": ["google.txt"]
 		},
 		{
 			"name": "nexusmods",

--- a/google.txt
+++ b/google.txt
@@ -1,2 +1,0 @@
-dl.google.com
-*.gvt1.com

--- a/windowsupdates.txt
+++ b/windowsupdates.txt
@@ -9,6 +9,3 @@ amupdatedl2.microsoft.com
 amupdatedl3.microsoft.com
 amupdatedl4.microsoft.com
 amupdatedl5.microsoft.com
-*.tlu.dl.delivery.mp.microsoft.com
-officecdn.microsoft.com
-officecdn.microsoft.com.edgesuite.net


### PR DESCRIPTION
Reverts uklans/cache-domains#199

Reverting due to #200 more testing required and play store/adobe downloads at not core target for lan parties. If testing can be revalidate then this can be remerged