### PR TITLE
Tell dnsmasq not to pass requests upstream

### DIFF
--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -52,10 +52,12 @@ while read -r entry; do
                                 fi
                                 parsed=$(echo ${fileentry} | sed -e "s/^\*\.//")
                                 for i in ${cacheip}; do
-                                        if grep -qx "address=/${parsed}/${i}" "${outputfile}"; then
-                                                continue
+                                        if ! grep -qx "local=/${parsed}/" "${outputfile}"; then
+                                                echo "local=/${parsed}/" >> "${outputfile}"
                                         fi
-                                        echo "address=/${parsed}/${i}" >> "${outputfile}"
+                                        if ! grep -qx "address=/${parsed}/${i}" "${outputfile}"; then
+                                                echo "address=/${parsed}/${i}" >> "${outputfile}"
+                                        fi
                                 done
                         done <<< $(cat ${basedir}/${filename} | sort);
                 done <<< $(jq -r ".cache_domains[${entry}].domain_files[$fileid]" ${path})

--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -52,11 +52,11 @@ while read -r entry; do
                                 fi
                                 parsed=$(echo ${fileentry} | sed -e "s/^\*\.//")
                                 for i in ${cacheip}; do
-                                        if ! grep -qx "local=/${parsed}/" "${outputfile}"; then
-                                                echo "local=/${parsed}/" >> "${outputfile}"
-                                        fi
                                         if ! grep -qx "address=/${parsed}/${i}" "${outputfile}"; then
                                                 echo "address=/${parsed}/${i}" >> "${outputfile}"
+                                        fi
+                                        if ! grep -qx "local=/${parsed}/" "${outputfile}"; then
+                                                echo "local=/${parsed}/" >> "${outputfile}"
                                         fi
                                 done
                         done <<< $(cat ${basedir}/${filename} | sort);


### PR DESCRIPTION
The behavior of dnsmasq changed in version 2.86 -- before then, if a record was set for a domain name with dnsmasq, and a record for a type not specified for that domain was requested, dnsmasq would indicate no data existed for that record type. After 2.86, record types that are not specified are instead passed upstream. The latter behavior causes problems for the Steam client, which will disregard a correctly set A-record for lancache.steamcontent.com, if no AAAA is set with dnsmasq and dnsmasq passes the AAAA query upstream. The documentation for dnsmasq indicates the correct way to restore the old behavior is to use the local=/host/ syntax -- emit this syntax for each of our lancache-hosted DNS entries.

### What CDN does this PR relate to
Steam

### Does this require running via sniproxy
N/A (create-dnsmasq.sh update)

### Capture method
N/A (create-dnsmasq.sh update)

### Testing Scenario
Home network, Linux, Windows, Steamdeck clients; OpenWRT (dnsmasq-based) router serving DNS. Deleted prior dnsmasq config, ran create-dnsmasq.sh, copied the generated output/dnsmasq/steam.conf file to the router's configuration directory for dnsmasq (/tmp/dnsmasq.d/), restarted dnsmasq on the router, and verified no AAAA record is served. Restarted Steam on each of the platforms, monitored the lancache access log, verified all three types of client access the cache correctly.

### Testing Configuration
```
local=/lancache.steamcontent.com/
address=/lancache.steamcontent.com/192.168.42.10
```

### Sniproxy output
N/A