### PR TITLE
Fixing wrong Epic domain

### DIFF
--- a/epicgames.txt
+++ b/epicgames.txt
@@ -10,4 +10,4 @@ download3.epicgames.com
 download4.epicgames.com
 epicgames-download1.akamaized.net
 fastly-download.epicgames.com
-cloudflare.epicgames.cdn
+cloudflare.epicgamescdn.com


### PR DESCRIPTION
Fixing wrong brainfart domain that I mentioned in #240.  Should be `cloudflare.epicgamescdn.com` instead of `cloudflare.epicgames.cdn`

