### PR TITLE
Remove EA services temporaliy

### DIFF
--- a/cache_domains.json
+++ b/cache_domains.json
@@ -51,13 +51,6 @@
 			"domain_files": ["nintendo.txt"]
 		},
 		{
-			"name": "origin",
-			"description": "CDN for origin",
-			"notes": "Should be enabled for HTTP traffic only or with a HTTPS proxy else origin client download fails",
-			"mixed_content": true,
-			"domain_files": ["origin.txt"]
-		},
-		{
 			"name": "pathofexile",
 			"description": "CDN for Path Of Exile",
 			"domain_files": ["pathofexile.txt"]


### PR DESCRIPTION
Removing EA services from cache temporarly as since the move from EA Origin to the EA app the config blocks updates to the EA app client.

### What CDN does this PR relate to
ea.com

### Does this require running via sniproxy
<!-- Yes/no/untested -->
Untested

### Capture method
<!-- Please give a short description how you ascertained the updates to the domain files, wireshark, dns logs etc -->
wireshark / glasswire
![image](https://github.com/uklans/cache-domains/assets/6136439/84eb5d37-f9e6-49bb-908d-b7eb111867f1)


### Testing Scenario
<!-- Please give a short description on how you have tested this and where (home, office, small lan, large lan etc) -->
Home / Small LAN

Tested by running the current version of cache_domains - EA app fails to download up with error code - EC10005,
Added several domains during testing via wireshark / glasswire logs - no change, additional ea.com appeared to be blocked when attempting to access via a browser with a 301 cache miss in lancache monolithic logs

### Testing Configuration
```
docker run --restart unless-stopped --name lancache --add-host=git.lab.net:192.168.1.117 --detach -v /cache/data:/data/cache -v /cache/logs:/data/logs -p 80:80 -e CACHE_DOMAINS_REPO="http://git.lab.net/Darren/cache-domains.git" -e CACHE_DOMAINS_BRANCH="master" -e UPSTREAM_DNS="1.1.1.1 1.0.0.1 8.8.8.8 8.8.4.4" -e CACHE_MAX_AGE=365d lancachenet/monolithic:latest
docker run --restart unless-stopped --name lancache-dns --add-host=git.lab.net:192.168.1.117 --detach -p 53:53/udp -e USE_GENERIC_CACHE=true -e LANCACHE_IP=192.168.1.5 -e CACHE_DOMAINS_REPO="http://git.lab.net/Darren/cache-domains.git" -e CACHE_DOMAINS_BRANCH="master" lancachenet/lancache-dns:latest
```
note: that git server listed in docker commands above is a local clone of this git repo for testing purposes / custom domains. However remains identical with this repo during testing.

EA appear appears to attempt to download via akami cdn's in my case before removing the origin config it was attempting to download the update via e16616.e12.akamaiedge.net however would hang or through a failed to download message regardless if added into the config or not.

### Sniproxy output
Please paste the output from `docker logs <sniproxy container name/id> | sed 's/.*\:443 \[//;s/\].*//' | sort | uniq -c` below
```
Not applicable
```

