### PR TITLE
Add gst.prod.dl.playstation.net and others back to sony.txt

### DIFF
--- a/sony.txt
+++ b/sony.txt
@@ -9,3 +9,8 @@ playstation4.sony.akadns.net
 theia.dl.playstation.net
 tmdb.np.dl.playstation.net
 gs-sec.ww.np.dl.playstation.net
+uef.np.dl.playstation.net
+gst.prod.dl.playstation.net
+vulcan.dl.playstation.net
+sgst.prod.dl.playstation.net
+psnobj.prod.dl.playstation.net


### PR DESCRIPTION
https://github.com/uklans/cache-domains/blob/7994db263e412d260f792fda6cc0f23dd3d02d52/sony.txt

### What CDN does this PR relate to
Stolen from https://github.com/uklans/cache-domains/pull/177
Adding these Playstation CDN hostnames back after the monolithic cache has had its configuration modified to handle the odd 302 slice response traffic.
https://github.com/lancachenet/monolithic/pull/156

### Does this require running via sniproxy
No

### Capture method
From packet capture and once finding the uncached traffic on our network finding old PR 177 confirming the domains.

### Testing Scenario
We ran these domains at PAXAUS 2024 against 30-40 PS5s successfully.

### Testing Configuration


### Sniproxy output
N/A

