### PR TITLE
Added new fastly cdn dns epicgames.txt

### DIFF
--- a/epicgames.txt
+++ b/epicgames.txt
@@ -11,3 +11,4 @@ download4.epicgames.com
 epicgames-download1.akamaized.net
 fastly-download.epicgames.com
 cloudflare.epicgamescdn.com
+egdownload.fastly-edge.com


### PR DESCRIPTION
Recently found epicgames using new cache domain to download content from Fastly CDN then looked for the IP and domain then found the committed domain.

[egdownload.fastly-edge.com] 103.14.145.249 / - - - [13/Jan/2025:03:43:56 +0600] "GET /Builds/Org/o-dhz7kpvrvqngzdpnx5vn3jrljj53ca/68d2cc08f9a94b8fb51af4f5cfa6d41b/default/ChunksV4/54/A22AC07FF687FF79_8BE04A9545854CE8C1BF05851D60D52D.chunk HTTP/1.1" 200 1048642 "-" "EpicGamesLauncher/17.2.1-38570976+++Portal+Release-Live Windows/10.0.26100.1.256.64bit" "MISS" "egdownload.fastly-edge.com" "-"

### What CDN does this PR relate to
This CDN is related to Epic Games. 

### Does this require running via sniproxy
Untested

### Capture method
I run and ISP and I use bind9 server to serve my clients. Recently noticed some downloads from epic not using my cache server. then started download to find destination IP address using mikrotik torch and windows resource monitor. Then used the 'ipconfig /displaydns to find the corresponding domain name. 

### Testing Scenario
Tested on live cache server being used in an ISP(Furious Internet) in bangladesh.

### Testing Configuration
partial rpz.db config file of my bind server running in a VM
```
;## epicgames
32.60.95.168.192.rpz-client-ip      CNAME rpz-passthru.;
cdn1.epicgames.com IN CNAME epicgames.cache.lancache.net.;
cdn2.epicgames.com IN CNAME epicgames.cache.lancache.net.;
cdn.unrealengine.com IN CNAME epicgames.cache.lancache.net.;
cdn1.unrealengine.com IN CNAME epicgames.cache.lancache.net.;
cdn2.unrealengine.com IN CNAME epicgames.cache.lancache.net.;
cdn3.unrealengine.com IN CNAME epicgames.cache.lancache.net.;
download.epicgames.com IN CNAME epicgames.cache.lancache.net.;
download2.epicgames.com IN CNAME epicgames.cache.lancache.net.;
download3.epicgames.com IN CNAME epicgames.cache.lancache.net.;
download4.epicgames.com IN CNAME epicgames.cache.lancache.net.;
epicgames-download1.akamaized.net IN CNAME epicgames.cache.lancache.net.;
fastly-download.epicgames.com IN CNAME epicgames.cache.lancache.net.;
cloudflare.epicgamescdn.com IN CNAME epicgames.cache.lancache.net.;
egdownload.fastly-edge.com IN CNAME epicgames.cache.lancache.net.;
```
log output of epic game download using the new domain
```
[egdownload.fastly-edge.com] 103.14.145.249 / - - - [13/Jan/2025:03:43:56 +0600] "GET /Builds/Org/o-dhz7kpvrvqngzdpnx5vn3jrljj53ca/68d2cc08f9a94b8fb51af4f5cfa6d41b/default/ChunksV4/54/A22AC07FF687FF79_8BE04A9545854CE8C1BF05851D60D52D.chunk HTTP/1.1" 200 1048642 "-" "EpicGamesLauncher/17.2.1-38570976+++Portal+Release-Live Windows/10.0.26100.1.256.64bit" "MISS" "egdownload.fastly-edge.com" "-"
```


