### PR TITLE
Add new CDN for ZenlessZoneZero

### DIFF
--- a/cache_domains.json
+++ b/cache_domains.json
@@ -121,6 +121,11 @@
 			"name": "xboxlive",
 			"description": "CDN for xboxlive",
 			"domain_files": ["xboxlive.txt"]
-		}
+		},
+        {
+            "name": "zzz",
+            "description": "CDN for ZenlessZoneZero (Not All Hoyoverse Games)",
+            "domain_files": ["zenlesszonezero.txt"]
+        }
 	]
 }

--- a/zenlesszonezero.txt
+++ b/zenlesszonezero.txt
@@ -1,0 +1,1 @@
+autopatchos.zenlesszonezero.com


### PR DESCRIPTION
### What CDN does this PR relate to
This CDN is for ZenlessZoneZero game ONLY

### Does this require running via sniproxy
untested

### Capture method
I use the AdGaurdHome on my home server to capture the CDN and using Wireguard to verify its IP while updating the game.
![image](https://github.com/user-attachments/assets/a51e6b57-09bd-49d9-bac3-185cdb9c33c4)


### Testing Scenario
I changing the CDN target from original source IP to my lancache container IP using the rewritten response that is from AdGaurdHome then start downloading the game again.
![image](https://github.com/user-attachments/assets/728bdfda-e31a-480b-aead-585e8cf4e6ff)
![image](https://github.com/user-attachments/assets/724061d4-f6e2-40e8-97ee-ae483e347311)

### Testing Configuration
Since I use AdGaurdHome as my DNS (I didn't use the lancache-dns) I used the script that you have to generate AdGaurdHome config file after I added the textfile and modified the cache_domain.json.
![image](https://github.com/user-attachments/assets/01628a3e-06da-4bd9-8ae6-965bedfd8b50)
![image](https://github.com/user-attachments/assets/6cde7fd1-6d90-4548-868a-0be6d3b5d3a2)

### Sniproxy output
I didn't use Sniproxy so I don't have any output for it.
