### PR TITLE
fix: explicitly specify ipv4 addresses

### DIFF
--- a/scripts/create-adguardhome.sh
+++ b/scripts/create-adguardhome.sh
@@ -59,7 +59,7 @@ while read entry; do
                     continue
                 fi
                 for i in ${cacheip}; do
-                    echo "${domainprefix}${parsed}^\$dnsrewrite=${i}" >> ${outputfile}
+                    echo "${domainprefix}${parsed}^\$dnsrewrite=${i},dnstype=A" >> ${outputfile}
                 done
             done <<< $(cat ${basedir}/$filename | sort);
         done <<< $(jq -r ".cache_domains[${entry}].domain_files[${fileid}]" ${path})


### PR DESCRIPTION
This change fixes the AdGuard Home generation script by disabling the return of ipv6 addresses. This would have been causing issues for users who are running dual-stack ipv4/6 with the addresses that accept both ipv4 and ipv6 traffic.