### PR TITLE
fix(nintendo): remove obsolete entry

### DIFF
--- a/nintendo.txt
+++ b/nintendo.txt
@@ -1,4 +1,3 @@
-ccs.cdn.wup.shop.nintendo.net
 ccs.cdn.wup.shop.nintendo.net.edgesuite.net
 geisha-wup.cdn.nintendo.net
 geisha-wup.cdn.nintendo.net.edgekey.net


### PR DESCRIPTION
The domain in question is already covered by a wildcard defined further in the list. In AdGuard Home this was causing said domain to have a round-robin DNS entry with the same IP twice.