### PR TITLE
fix: default cache in scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,4 @@ indent_size = 0
 
 [*.sh]
 indent_style = tab
+

--- a/scripts/create-adguardhome.sh
+++ b/scripts/create-adguardhome.sh
@@ -13,7 +13,6 @@ if ! command -v jq >/dev/null; then
 	exit 1
 fi
 
-cachenamedefault="disabled"
 combinedoutput=$(jq -r ".combined_output" config.json)
 
 while read -r line; do
@@ -34,7 +33,7 @@ while read -r entry; do
 	key=$(jq -r ".cache_domains[$entry].name" ${path})
 	cachename="cachename${key}"
 	if [ -z "${!cachename}" ]; then
-		cachename=${cachenamedefault}
+		cachename="cachenamedefault"
 	fi
 	if [[ ${cachename} == "disabled" ]]; then
 		continue

--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -13,7 +13,6 @@ if ! command -v jq >/dev/null; then
 	exit 1
 fi
 
-cachenamedefault="disabled"
 combinedoutput=$(jq -r ".combined_output" config.json)
 
 while read -r line; do
@@ -34,7 +33,7 @@ while read -r entry; do
 	key=$(jq -r ".cache_domains[${entry}].name" ${path})
 	cachename="cachename${key}"
 	if [ -z "${!cachename}" ]; then
-		cachename=${cachenamedefault}
+		cachename="cachenamedefault"
 	fi
 	if [[ ${cachename} == "disabled" ]]; then
 		continue

--- a/scripts/create-rpz.sh
+++ b/scripts/create-rpz.sh
@@ -14,8 +14,6 @@ if ! command -v jq >/dev/null; then
 	exit 1
 fi
 
-cachenamedefault="disabled"
-
 while read -r line; do
 	ip=$(jq ".ips[\"${line}\"]" config.json)
 	declare "cacheip${line}"="${ip}"
@@ -50,7 +48,7 @@ while read -r entry; do
 	key=$(jq -r ".cache_domains[${entry}].name" ${path})
 	cachename="cachename${key}"
 	if [ -z "${!cachename}" ]; then
-		cachename=${cachenamedefault}
+		cachename="cachenamedefault"
 	fi
 	if [[ ${cachename} == "disabled" ]]; then
 		continue

--- a/scripts/create-squid.sh
+++ b/scripts/create-squid.sh
@@ -14,8 +14,6 @@ if ! command -v jq >/dev/null; then
 	exit 1
 fi
 
-cachenamedefault="disabled"
-
 while read -r line; do
 	name=$(jq -r ".cache_domains[\"${line}\"]" config.json)
 	declare "cachename${line}"="${name}"
@@ -28,7 +26,7 @@ while read -r entry; do
 	key=$(jq -r ".cache_domains[$entry].name" ${path})
 	cachename="cachename${key}"
 	if [ -z "${!cachename}" ]; then
-		cachename=${cachenamedefault}
+		cachename="cachenamedefault"
 	fi
 	if [[ ${cachename} == "disabled" ]]; then
 		continue

--- a/scripts/create-unbound.sh
+++ b/scripts/create-unbound.sh
@@ -13,7 +13,6 @@ if ! command -v jq >/dev/null; then
 	exit 1
 fi
 
-cachenamedefault="disabled"
 combinedoutput=$(jq -r ".combined_output" config.json)
 
 while read -r line; do
@@ -34,7 +33,7 @@ while read -r entry; do
 	key=$(jq -r ".cache_domains[${entry}].name" ${path})
 	cachename="cachename${key}"
 	if [ -z "${!cachename}" ]; then
-		cachename=${cachenamedefault}
+		cachename="cachenamedefault"
 	fi
 	if [[ ${cachename} == "disabled" ]]; then
 		continue


### PR DESCRIPTION
This change restores the ability to use the `default` cache within the generation scripts, as a bug was introduced in https://github.com/uklans/cache-domains/commit/098c1e9c54556c6da64695cf3cdfeee13f011193, which previously removed this ability.

Fixes #273.